### PR TITLE
Refine maintenance status insights

### DIFF
--- a/base.html
+++ b/base.html
@@ -8,16 +8,6 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
-      theme: {<!DOCTYPE html>
-<html lang="es">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Flota TRACK - Registro de Surcos</title>
-
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
       theme: {
         extend: {
           colors: {
@@ -43,17 +33,42 @@
     .tab-button.active { border-bottom-color: #059669; font-weight: 600; color: #059669; }
     .form-control { border-radius: 0.5rem; border: 1px solid #d1d5db; padding: 0.5rem 0.75rem; width: 100%; transition: all 0.15s; }
     .form-control:focus { border-color: #059669; box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.2); outline: none; }
+    .filter-input {
+        width: 100%;
+        padding: 4px 8px;
+        border: 1px solid #e5e7eb;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+    }
+    .filter-input:focus {
+        outline: none;
+        border-color: #059669;
+        box-shadow: 0 0 0 2px rgba(5, 150, 105, 0.2);
+    }
+    .input-valid {
+        border-color: #059669 !important;
+        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.15) !important;
+    }
+    .input-invalid {
+        border-color: #dc2626 !important;
+        box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.2) !important;
+    }
+    .readonly-input {
+        background-color: #f3f4f6;
+        color: #4b5563;
+        cursor: not-allowed;
+    }
   </style>
 
-  <!-- Librerías para generar PDF -->
+  <!-- Librerías para generar PDF y Excel -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
     import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
     import { getFirestore, addDoc, onSnapshot, collection, query, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-    import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 
     // === CONFIGURACIÓN ===
     const GEMINI_MODEL = "gemini-2.5-flash-preview-05-20";
@@ -71,6 +86,22 @@
       'Michelin X Multiway 3D XZE', 'Pirelli FH:01 Energy', 'Bridgestone R260', 'Dunlop SP338', 'Goodyear KMAX S', 'Continental HT3', 'Hankook SmartFlex AH31', 'Westlake CB867', 'Sailun S701'
     ];
     const PREDEFINED_SIZES = ['225/75R16', '245/70R19.5', '275/80R22.5', '295/80R22.5', '315/80R22.5', '11R22.5', '12R22.5', '10.00R20'];
+    const FLEET_SHARE_ID = 'u!aHR0cHM6Ly8xZHJ2Lm1zL3gvYy80ZTllNTI1OTI0MGMzNzFiL0VSczNEQ1JaVXA0Z2dFNlJBQUFBQUFBQlRScUl1ZGJRRXRWUDN3akdkSVkxbXc_ZT13Z0tvUTk';
+    const FLEET_GRAPH_CONTENT_URL = `https://graph.microsoft.com/v1.0/shares/${FLEET_SHARE_ID}/driveItem/content`;
+    const FLEET_GITHUB_FALLBACK_URL = 'https://raw.githubusercontent.com/jeremyispoken/Neumaticos/4964bf87b8cf5f423cc3e55eed17951b4e8dc36d/DATAVEHICULOS';
+    const FLEET_SHEET_NAME = 'Flota Verschae';
+    const ORDER_KEYWORDS = ['orden', 'n° orden', 'nº orden', 'numero orden', 'orden vehículo', 'orden vehiculo'];
+    const MOBILE_KEYWORDS = ['móvil', 'movil', 'n° movil', 'nº movil', 'nro movil', 'numero movil'];
+    const PLATE_KEYWORDS = ['patente', 'placa', 'matricula'];
+    const MILEAGE_KEYWORDS = ['kilometraje', 'km', 'kilometros', 'kilómetros', 'odometro', 'odómetro'];
+    const FLEET_FALLBACK_INDEX = { order: 2, mobile: 2, plate: 3, mileage: 13 };
+    const CATALOG_STORAGE_KEY = 'flota-track-catalog';
+    const ONEDRIVE_TOKEN_ENDPOINT = 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token';
+    const ONEDRIVE_CLIENT_ID = '04b07795-8ddb-461a-bbee-02f9e1bf7b46';
+    const ONEDRIVE_SCOPE = 'https://graph.microsoft.com/.default offline_access';
+    const ONEDRIVE_USERNAME = 'verschae@outlook.com';
+    const ONEDRIVE_PASSWORD = 'Berlioz5761';
+    const ONEDRIVE_SESSION_STORAGE_KEY = 'flota-track-onedrive-session';
     const longevityTips = [
       "Mantén la <strong>presión correcta</strong> semanalmente. La subinflación es el principal asesino de neumáticos.",
       "Realiza la <strong>rotación</strong> cada 10–12 mil km para asegurar un desgaste uniforme.",
@@ -83,12 +114,650 @@
     ];
 
     // === ESTADO GLOBAL DE LA APLICACIÓN ===
-    let app = null, db = null, auth = null, storage = null;
+    let app = null, db = null, auth = null;
     let currentUserId = null;
     let authReady = false;
     let unsubscribeRecords = null;
     window.currentRecords = [];
     window.pendingReviewData = null;
+    let fleetLookup = new Map();
+    let fleetEntries = [];
+    let fleetLoadStatus = 'idle';
+    let fleetLoadError = '';
+    let customModels = [];
+    let customSizes = [];
+    let onedriveSession = restoreOneDriveSession();
+    let onedriveAuthPromise = null;
+
+    function normalizeOrderKey(value) {
+      if (value === null || value === undefined) return '';
+      return String(value).trim().toUpperCase().replace(/\s+/g, '');
+    }
+
+    function findColumnIndex(headers, keywords, fallbackIndex) {
+      if (!Array.isArray(headers)) return fallbackIndex;
+      const index = headers.findIndex((header) => {
+        const normalizedHeader = String(header || '').trim().toLowerCase();
+        return keywords.some(keyword => normalizedHeader.includes(keyword));
+      });
+      return index !== -1 ? index : fallbackIndex;
+    }
+
+    function safeCellValue(row, index) {
+      if (!Array.isArray(row) || typeof index !== 'number' || index < 0) return '';
+      if (index >= row.length) return '';
+      const value = row[index];
+      if (value === null || value === undefined) return '';
+      return String(value).trim();
+    }
+
+    function restoreOneDriveSession() {
+      const defaultSession = { accessToken: '', refreshToken: '', expiresAt: 0 };
+      try {
+        const stored = sessionStorage.getItem(ONEDRIVE_SESSION_STORAGE_KEY);
+        if (!stored) return { ...defaultSession };
+        const parsed = JSON.parse(stored);
+        return {
+          accessToken: typeof parsed.accessToken === 'string' ? parsed.accessToken : '',
+          refreshToken: typeof parsed.refreshToken === 'string' ? parsed.refreshToken : '',
+          expiresAt: typeof parsed.expiresAt === 'number' ? parsed.expiresAt : 0,
+        };
+      } catch (error) {
+        console.warn('No se pudo restaurar la sesión de OneDrive almacenada:', error);
+        return { ...defaultSession };
+      }
+    }
+
+    function persistOneDriveSession(session) {
+      try {
+        sessionStorage.setItem(ONEDRIVE_SESSION_STORAGE_KEY, JSON.stringify(session));
+      } catch (error) {
+        console.warn('No se pudo persistir la sesión de OneDrive:', error);
+      }
+    }
+
+    function clearOneDriveSession() {
+      onedriveSession = { accessToken: '', refreshToken: '', expiresAt: 0 };
+      persistOneDriveSession(onedriveSession);
+    }
+
+    async function ensureOneDriveAccessToken({ forceRefresh = false } = {}) {
+      const now = Date.now();
+      if (!forceRefresh && onedriveSession.accessToken && now < (onedriveSession.expiresAt - 60000)) {
+        return onedriveSession.accessToken;
+      }
+
+      if (onedriveAuthPromise) {
+        return onedriveAuthPromise;
+      }
+
+      onedriveAuthPromise = (async () => {
+        if (!forceRefresh && onedriveSession.refreshToken) {
+          try {
+            return await requestOneDriveToken({ grantType: 'refresh_token', refreshToken: onedriveSession.refreshToken });
+          } catch (error) {
+            console.warn('No se pudo refrescar el token de OneDrive:', error);
+          }
+        }
+        return await requestOneDriveToken({ grantType: 'password' });
+      })()
+        .catch((error) => {
+          clearOneDriveSession();
+          throw error;
+        })
+        .finally(() => {
+          onedriveAuthPromise = null;
+        });
+
+      return onedriveAuthPromise;
+    }
+
+    async function requestOneDriveToken({ grantType, refreshToken }) {
+      const params = new URLSearchParams({
+        client_id: ONEDRIVE_CLIENT_ID,
+        scope: ONEDRIVE_SCOPE,
+      });
+
+      if (grantType === 'refresh_token') {
+        params.set('grant_type', 'refresh_token');
+        params.set('refresh_token', refreshToken || '');
+      } else {
+        params.set('grant_type', 'password');
+        params.set('username', ONEDRIVE_USERNAME);
+        params.set('password', ONEDRIVE_PASSWORD);
+      }
+
+      const response = await fetch(ONEDRIVE_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params,
+        cache: 'no-store',
+        credentials: 'omit',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Error ${response.status} al autenticar en OneDrive.`);
+      }
+
+      const payload = await response.json();
+      if (!payload.access_token) {
+        throw new Error('La autenticación de OneDrive no devolvió un access_token.');
+      }
+
+      const expiresIn = Number(payload.expires_in) || 3600;
+      onedriveSession = {
+        accessToken: payload.access_token,
+        refreshToken: typeof payload.refresh_token === 'string' ? payload.refresh_token : (refreshToken || ''),
+        expiresAt: Date.now() + Math.max(60, expiresIn - 60) * 1000,
+      };
+      persistOneDriveSession(onedriveSession);
+      return onedriveSession.accessToken;
+    }
+
+    function loadCatalogFromStorage() {
+      try {
+        const stored = localStorage.getItem(CATALOG_STORAGE_KEY);
+        if (!stored) return;
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed.models)) customModels = parsed.models.filter(Boolean);
+        if (Array.isArray(parsed.sizes)) customSizes = parsed.sizes.filter(Boolean);
+      } catch (error) {
+        console.warn('No se pudo cargar el catálogo personalizado:', error);
+        customModels = [];
+        customSizes = [];
+      }
+    }
+
+    function saveCatalogToStorage() {
+      const payload = {
+        models: customModels.filter(Boolean),
+        sizes: customSizes.filter(Boolean)
+      };
+      try {
+        localStorage.setItem(CATALOG_STORAGE_KEY, JSON.stringify(payload));
+      } catch (error) {
+        console.warn('No se pudo guardar el catálogo personalizado:', error);
+      }
+    }
+
+    function getAvailableMakeModels() {
+      return Array.from(new Set([...PREDEFINED_MODELS, ...customModels.filter(Boolean)])).sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    }
+
+    function getAvailableTireSizes() {
+      return Array.from(new Set([...PREDEFINED_SIZES, ...customSizes.filter(Boolean)])).sort((a, b) => a.localeCompare(b, 'es', { numeric: true, sensitivity: 'base' }));
+    }
+
+    function getMakeModelOptionsMarkup() {
+      return getAvailableMakeModels().map((model) => `<option value="${model}">${model}</option>`).join('');
+    }
+
+    function refreshCatalogSelects() {
+      const makeModelSelect = document.getElementById('makeModel');
+      if (makeModelSelect) {
+        const previous = makeModelSelect.value;
+        makeModelSelect.innerHTML = '<option value="" disabled selected>Selecciona una marca...</option>' + getMakeModelOptionsMarkup();
+        if (previous && getAvailableMakeModels().includes(previous)) {
+          makeModelSelect.value = previous;
+        }
+      }
+
+      const tireSizeSelect = document.getElementById('tireSize');
+      if (tireSizeSelect) {
+        const previousSize = tireSizeSelect.value;
+        tireSizeSelect.innerHTML = '<option value="" disabled selected>Selecciona una medida...</option>' + getAvailableTireSizes().map((size) => `<option value="${size}">${size}</option>`).join('');
+        if (previousSize && getAvailableTireSizes().includes(previousSize)) {
+          tireSizeSelect.value = previousSize;
+        }
+      }
+
+      updatePerTireModelSelects();
+    }
+
+    function updatePerTireModelSelects() {
+      const optionsMarkup = getMakeModelOptionsMarkup();
+      document.querySelectorAll('select[id^="tireMakeModel-"]').forEach((select) => {
+        const previous = select.value;
+        select.innerHTML = '<option value="" selected>Usar marca general del formulario</option>' + optionsMarkup;
+        if (previous && getAvailableMakeModels().includes(previous)) {
+          select.value = previous;
+        }
+      });
+    }
+
+    function renderCatalogLists() {
+      const modelList = document.getElementById('customModelList');
+      if (modelList) {
+        if (customModels.length === 0) {
+          modelList.innerHTML = '<p class="text-sm text-gray-500">Aún no registras modelos personalizados.</p>';
+        }
+        else {
+          modelList.innerHTML = customModels.map((item) => `<span class="px-3 py-1 bg-primary/10 text-primary rounded-full text-xs font-semibold">${item}</span>`).join(' ');
+        }
+      }
+      const sizeList = document.getElementById('customSizeList');
+      if (sizeList) {
+        if (customSizes.length === 0) {
+          sizeList.innerHTML = '<p class="text-sm text-gray-500">Aún no registras medidas personalizadas.</p>';
+        }
+        else {
+          sizeList.innerHTML = customSizes.map((item) => `<span class="px-3 py-1 bg-secondary/10 text-secondary rounded-full text-xs font-semibold">${item}</span>`).join(' ');
+        }
+      }
+    }
+
+    function showAdminFeedback(message, type = 'info') {
+      const container = document.getElementById('adminFeedback');
+      if (!container) return;
+      const typeClasses = {
+        success: 'text-green-600',
+        error: 'text-red-600',
+        info: 'text-gray-600',
+        warning: 'text-amber-600'
+      };
+      container.textContent = message;
+      container.className = `mt-4 text-sm font-medium ${typeClasses[type] || typeClasses.info}`;
+    }
+
+    window.handleAdminAddModel = function(event) {
+      event.preventDefault();
+      const input = document.getElementById('newModel');
+      if (!input) return;
+      const value = input.value.trim();
+      if (!value) {
+        showAdminFeedback('Ingresa una marca o modelo válido.', 'error');
+        return;
+      }
+      if (getAvailableMakeModels().some(item => item.toLowerCase() === value.toLowerCase())) {
+        showAdminFeedback('Ese modelo ya existe en el catálogo.', 'warning');
+        input.value = '';
+        return;
+      }
+      customModels.push(value);
+      customModels = Array.from(new Set(customModels));
+      saveCatalogToStorage();
+      refreshCatalogSelects();
+      renderCatalogLists();
+      showAdminFeedback(`Modelo "${value}" agregado correctamente.`, 'success');
+      input.value = '';
+    };
+
+    window.handleAdminAddSize = function(event) {
+      event.preventDefault();
+      const input = document.getElementById('newSize');
+      if (!input) return;
+      const value = input.value.trim().toUpperCase();
+      if (!value) {
+        showAdminFeedback('Ingresa una medida válida.', 'error');
+        return;
+      }
+      if (getAvailableTireSizes().some(item => item.toLowerCase() === value.toLowerCase())) {
+        showAdminFeedback('Esa medida ya existe en el catálogo.', 'warning');
+        input.value = '';
+        return;
+      }
+      customSizes.push(value);
+      customSizes = Array.from(new Set(customSizes));
+      saveCatalogToStorage();
+      refreshCatalogSelects();
+      renderCatalogLists();
+      showAdminFeedback(`Medida "${value}" agregada correctamente.`, 'success');
+      input.value = '';
+    };
+
+    function attachOrderNumberHandlers() {
+      const orderInput = document.getElementById('orderNumber');
+      if (!orderInput) return;
+      orderInput.addEventListener('input', handleOrderNumberInput);
+      orderInput.addEventListener('change', handleOrderNumberInput);
+      orderInput.addEventListener('blur', handleOrderNumberInput);
+    }
+
+    function setOrderInputState(status, error) {
+      fleetLoadStatus = status;
+      fleetLoadError = error ? String(error) : '';
+      const orderInput = document.getElementById('orderNumber');
+      const feedback = document.getElementById('orderNumberFeedback');
+      if (!orderInput || !feedback) return;
+      if (status === 'loading') {
+        orderInput.placeholder = 'Cargando catálogo de flota...';
+        feedback.textContent = 'Conectando a la hoja "Flota Verschae"...';
+        feedback.className = 'mt-1 text-xs text-gray-500';
+      } else if (status === 'ready') {
+        orderInput.placeholder = 'Escribe o selecciona una orden de la flota';
+        if (!orderInput.value.trim()) {
+          feedback.textContent = 'Selecciona la orden desde la planilla para evitar errores.';
+          feedback.className = 'mt-1 text-xs text-gray-500';
+        }
+      } else if (status === 'error') {
+        orderInput.placeholder = 'Ingresa el número de orden';
+        feedback.textContent = 'No se pudo validar automáticamente. Ingresa el N° manualmente y verifica en la planilla.';
+        feedback.className = 'mt-1 text-xs text-amber-600';
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+      }
+    }
+
+    function refreshOrderDatalist() {
+      const datalist = document.getElementById('orderNumberOptions');
+      if (!datalist) return;
+      datalist.innerHTML = '';
+      if (!fleetEntries.length) return;
+      const sorted = [...fleetEntries].sort((a, b) => compareOrderNumbers(a.orderNumber, b.orderNumber));
+      sorted.forEach((entry) => {
+        const value = entry.orderNumber || entry.normalizedOrder;
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = entry.plate ? `${value} · ${entry.plate}` : value;
+        datalist.appendChild(option);
+      });
+    }
+
+    function handleOrderNumberInput() {
+      const orderInput = document.getElementById('orderNumber');
+      const plateInput = document.getElementById('vehiclePlate');
+      const feedback = document.getElementById('orderNumberFeedback');
+      const mileageInput = document.getElementById('mileage');
+      if (!orderInput || !feedback) return;
+      const rawValue = orderInput.value || '';
+      const normalized = normalizeOrderKey(rawValue);
+
+      if (!rawValue.trim()) {
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+        if (feedback) {
+          feedback.textContent = fleetLoadStatus === 'ready' ? 'Selecciona la orden desde la planilla para evitar errores.' : feedback.textContent;
+          feedback.className = 'mt-1 text-xs text-gray-500';
+        }
+        if (plateInput) plateInput.value = '';
+        if (mileageInput) mileageInput.value = '';
+        return;
+      }
+
+      if (fleetLookup.has(normalized)) {
+        const match = fleetLookup.get(normalized);
+        if (match) {
+          orderInput.value = match.orderNumber || rawValue.trim();
+          orderInput.classList.add('input-valid');
+          orderInput.classList.remove('input-invalid');
+          orderInput.setCustomValidity('');
+          if (feedback) {
+            feedback.textContent = match.plate ? `Patente encontrada: ${match.plate}` : 'Orden validada en la flota.';
+            feedback.className = 'mt-1 text-xs text-green-600';
+          }
+          if (plateInput) {
+            plateInput.value = match.plate || 'Sin patente registrada';
+          }
+          if (mileageInput && match.mileage !== null && match.mileage !== undefined && match.mileage !== '') {
+            mileageInput.value = match.mileage;
+          }
+          return;
+        }
+      }
+
+      if (fleetLoadStatus === 'error') {
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+        if (feedback) {
+          feedback.textContent = 'No se pudo validar con la planilla. Verifica manualmente el N° de móvil (columna C).';
+          feedback.className = 'mt-1 text-xs text-amber-600';
+        }
+      } else {
+        orderInput.classList.add('input-invalid');
+        orderInput.classList.remove('input-valid');
+        orderInput.setCustomValidity('Número de móvil no encontrado en la hoja "Flota Verschae". Revisa la columna C.');
+        if (feedback) {
+          feedback.textContent = 'Número incorrecto. Confirma el N° de móvil (columna C) en la planilla.';
+          feedback.className = 'mt-1 text-xs text-red-600';
+        }
+      }
+      if (plateInput) plateInput.value = '';
+      if (mileageInput) mileageInput.value = '';
+    }
+
+    function resetOrderAutofill() {
+      const orderInput = document.getElementById('orderNumber');
+      const plateInput = document.getElementById('vehiclePlate');
+      const feedback = document.getElementById('orderNumberFeedback');
+      if (orderInput) {
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+        orderInput.value = '';
+      }
+      if (plateInput) plateInput.value = '';
+      if (feedback) {
+        feedback.textContent = fleetLoadStatus === 'ready' ? 'Selecciona la orden desde la planilla para evitar errores.' : 'Número de orden del vehículo.';
+        feedback.className = 'mt-1 text-xs text-gray-500';
+      }
+    }
+
+    async function loadFleetDataset() {
+      setOrderInputState('loading');
+      try {
+        const { entries, lookup } = await fetchFleetDataset();
+        fleetEntries = entries;
+        fleetLookup = lookup;
+        setOrderInputState('ready');
+        refreshOrderDatalist();
+        handleOrderNumberInput();
+      } catch (error) {
+        console.error('No se pudo cargar la planilla de flota:', error);
+        fleetLookup = new Map();
+        fleetEntries = [];
+        setOrderInputState('error', error);
+      }
+    }
+
+    async function downloadOneDriveWorkbook({ allowRetry = true, forceReauth = false } = {}) {
+      if (typeof XLSX === 'undefined') {
+        throw new Error('La librería XLSX no está disponible para procesar la planilla de OneDrive.');
+      }
+
+      const token = await ensureOneDriveAccessToken({ forceRefresh: forceReauth });
+      if (!token) {
+        throw new Error('No se pudo obtener un token de acceso para OneDrive.');
+      }
+
+      const response = await fetch(FLEET_GRAPH_CONTENT_URL, {
+        method: 'GET',
+        cache: 'no-store',
+        mode: 'cors',
+        credentials: 'omit',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/octet-stream',
+        },
+      });
+
+      if (response.status === 401 || response.status === 403) {
+        if (allowRetry) {
+          console.warn('Token de OneDrive rechazado, reintentando autenticación completa…');
+          clearOneDriveSession();
+          return downloadOneDriveWorkbook({ allowRetry: false, forceReauth: true });
+        }
+        throw new Error(`Acceso denegado por OneDrive (${response.status}).`);
+      }
+
+      if (!response.ok) {
+        throw new Error(`Error ${response.status} al obtener la planilla desde OneDrive.`);
+      }
+
+      return response.arrayBuffer();
+    }
+
+    async function fetchFleetDataset() {
+      const hasSpreadsheetParser = typeof XLSX !== 'undefined';
+      const errors = [];
+
+      if (hasSpreadsheetParser) {
+        try {
+          const arrayBuffer = await downloadOneDriveWorkbook();
+          return parseFleetWorkbook(arrayBuffer);
+        } catch (error) {
+          errors.push(error);
+          console.warn('Fallo al descargar desde OneDrive autenticado, intentando respaldo GitHub…', error);
+        }
+      } else {
+        errors.push(new Error('XLSX no disponible para leer la planilla de OneDrive.'));
+      }
+
+      try {
+        const response = await fetch(FLEET_GITHUB_FALLBACK_URL, { cache: 'no-store', mode: 'cors' });
+        if (!response.ok) {
+          throw new Error(`Error ${response.status} al obtener el respaldo de GitHub`);
+        }
+
+        const contentType = (response.headers.get('content-type') || '').toLowerCase();
+        if (hasSpreadsheetParser && (contentType.includes('spreadsheetml') || contentType.includes('application/octet-stream'))) {
+          const arrayBuffer = await response.arrayBuffer();
+          return parseFleetWorkbook(arrayBuffer);
+        }
+
+        const textPayload = await response.text();
+        const trimmed = textPayload.trim();
+
+        if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+          const json = JSON.parse(trimmed);
+          return parseFleetJson(json);
+        }
+
+        if (trimmed.startsWith('http')) {
+          if (hasSpreadsheetParser) {
+            const arrayBuffer = await fetchAsArrayBuffer(trimmed);
+            return parseFleetWorkbook(arrayBuffer);
+          }
+          throw new Error('Se requiere XLSX para leer el enlace alternativo de la planilla.');
+        }
+
+        return parseFleetCsv(trimmed);
+      } catch (error) {
+        errors.push(error);
+        console.error('Fallo al usar el respaldo GitHub:', error);
+      }
+
+      const combinedError = new Error(errors.map(err => err?.message || String(err)).join(' | '));
+      combinedError.details = errors;
+      throw combinedError;
+    }
+
+    async function fetchAsArrayBuffer(url) {
+      const response = await fetch(url, { cache: 'no-store', mode: 'cors' });
+      if (!response.ok) {
+        throw new Error(`Error ${response.status} al obtener ${url}`);
+      }
+      return response.arrayBuffer();
+    }
+
+    function parseFleetWorkbook(arrayBuffer) {
+      const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+      const sheet = workbook.Sheets[FLEET_SHEET_NAME];
+      if (!sheet) {
+        throw new Error(`La hoja "${FLEET_SHEET_NAME}" no existe en el archivo.`);
+      }
+      const rows = XLSX.utils.sheet_to_json(sheet, { header: 1, defval: '' });
+      return buildFleetEntriesFromRows(rows);
+    }
+
+    function parseFleetJson(jsonPayload) {
+      if (!Array.isArray(jsonPayload)) {
+        throw new Error('El respaldo JSON de flota debe ser un arreglo.');
+      }
+      const entries = [];
+      const lookup = new Map();
+      jsonPayload.forEach((item) => {
+        if (!item) return;
+        const displayOrder = item.orderNumber || item.orden || item.order || '';
+        const normalizedOrder = normalizeOrderKey(displayOrder || item.mobile || item.movil);
+        if (!normalizedOrder) return;
+        const plate = String(item.plate || item.patente || '').toUpperCase().trim();
+        const mileageValue = item.mileage ?? item.kilometraje ?? item.km ?? null;
+        const mileage = mileageValue === null || mileageValue === undefined ? null : parseInt(String(mileageValue).replace(/[^0-9]/g, ''), 10);
+        const entry = {
+          orderNumber: displayOrder || normalizedOrder,
+          normalizedOrder,
+          plate,
+          mileage: Number.isFinite(mileage) ? mileage : null
+        };
+        entries.push(entry);
+        if (!lookup.has(normalizedOrder)) {
+          lookup.set(normalizedOrder, entry);
+        }
+      });
+      if (!entries.length) {
+        throw new Error('El respaldo JSON no contiene registros válidos.');
+      }
+      return { entries, lookup };
+    }
+
+    function parseFleetCsv(textPayload) {
+      const rows = textPayload.split(/\r?\n/).map(row => row.split(/\s*[,;\t]\s*/));
+      return buildFleetEntriesFromRows(rows);
+    }
+
+    function buildFleetEntriesFromRows(rows) {
+      if (!rows.length) {
+        throw new Error('La hoja seleccionada está vacía.');
+      }
+      const headers = rows[0];
+      const maxColumns = rows.reduce((max, row) => Array.isArray(row) ? Math.max(max, row.length) : max, Array.isArray(headers) ? headers.length : 0);
+      const clampIndex = (candidate, fallbackPreference) => {
+        if (typeof candidate === 'number' && candidate >= 0 && candidate < maxColumns) {
+          return candidate;
+        }
+        const adjusted = typeof fallbackPreference === 'number' ? fallbackPreference : 0;
+        if (maxColumns === 0) return 0;
+        if (adjusted >= 0 && adjusted < maxColumns) return adjusted;
+        return Math.max(0, Math.min(maxColumns - 1, adjusted));
+      };
+
+      const orderIndex = clampIndex(findColumnIndex(headers, ORDER_KEYWORDS, FLEET_FALLBACK_INDEX.order), 0);
+      const mobileIndex = clampIndex(findColumnIndex(headers, MOBILE_KEYWORDS, FLEET_FALLBACK_INDEX.mobile), orderIndex);
+      const plateIndex = clampIndex(findColumnIndex(headers, PLATE_KEYWORDS, FLEET_FALLBACK_INDEX.plate), Math.min(1, maxColumns - 1));
+      const mileageIndex = clampIndex(findColumnIndex(headers, MILEAGE_KEYWORDS, FLEET_FALLBACK_INDEX.mileage), Math.min(2, maxColumns - 1));
+
+      const entries = [];
+      const lookup = new Map();
+
+      rows.slice(1).forEach((row) => {
+        if (!row || row.every(cell => String(cell || '').trim() === '')) return;
+        const rawOrder = safeCellValue(row, orderIndex);
+        const rawMobile = safeCellValue(row, mobileIndex);
+        const displayOrder = rawOrder || rawMobile;
+        const normalizedOrder = normalizeOrderKey(displayOrder || rawMobile);
+        if (!normalizedOrder) return;
+        const plate = safeCellValue(row, plateIndex).toUpperCase();
+        const mileageValue = safeCellValue(row, mileageIndex);
+        const mileage = mileageValue ? parseInt(String(mileageValue).replace(/[^0-9]/g, ''), 10) : null;
+        const entry = {
+          orderNumber: displayOrder || normalizedOrder,
+          normalizedOrder,
+          plate,
+          mileage: Number.isFinite(mileage) ? mileage : null
+        };
+        entries.push(entry);
+        if (!lookup.has(normalizedOrder)) {
+          lookup.set(normalizedOrder, entry);
+        }
+      });
+
+      if (!entries.length) {
+        throw new Error('No se encontraron registros válidos en la hoja.');
+      }
+
+      return { entries, lookup };
+    }
+
+    function compareOrderNumbers(a, b) {
+      const valueA = normalizeOrderKey(a);
+      const valueB = normalizeOrderKey(b);
+      if (valueA === valueB) return 0;
+      const numericA = parseInt(valueA.replace(/[^0-9]/g, ''), 10);
+      const numericB = parseInt(valueB.replace(/[^0-9]/g, ''), 10);
+      if (Number.isFinite(numericA) && Number.isFinite(numericB) && numericA !== numericB) {
+        return numericA - numericB;
+      }
+      return valueA.localeCompare(valueB, 'es', { numeric: true, sensitivity: 'base' });
+    }
 
     // --- TUS CREDENCIALES DE FIREBASE ---
     const firebaseConfig = {
@@ -110,7 +779,6 @@
       try {
         app = initializeApp(firebaseConfig);
         db = getFirestore(app);
-        storage = getStorage(app);
         auth = getAuth(app);
 
         onAuthStateChanged(auth, user => {
@@ -169,31 +837,92 @@
         window.currentRecords = records.sort((a, b) => new Date(b.date) - new Date(a.date));
         
         const branchFilter = document.getElementById('branchFilter');
+        const branchColumnFilter = document.getElementById('branchColumnFilter');
         const uniqueBranches = [...new Set(window.currentRecords.map(r => r.branchName).filter(Boolean))];
-        
-        const currentFilterValue = branchFilter.value;
-        while (branchFilter.options.length > 1) {
-            branchFilter.remove(1);
+        const sortedBranches = uniqueBranches.sort((a, b) => a.localeCompare(b));
+
+        if (branchFilter) {
+            const currentFilterValue = branchFilter.value;
+            while (branchFilter.options.length > 1) {
+                branchFilter.remove(1);
+            }
+            sortedBranches.forEach(branch => {
+                const option = document.createElement('option');
+                option.value = branch;
+                option.textContent = branch;
+                branchFilter.appendChild(option);
+            });
+            if (currentFilterValue && sortedBranches.includes(currentFilterValue)) {
+                branchFilter.value = currentFilterValue;
+            } else {
+                branchFilter.value = 'all';
+            }
         }
-        uniqueBranches.sort().forEach(branch => {
-            const option = document.createElement('option');
-            option.value = branch;
-            option.textContent = branch;
-            branchFilter.appendChild(option);
-        });
-        branchFilter.value = currentFilterValue;
+
+        if (branchColumnFilter) {
+            const currentColumnValue = branchColumnFilter.value;
+            while (branchColumnFilter.options.length > 1) {
+                branchColumnFilter.remove(1);
+            }
+            sortedBranches.forEach(branch => {
+                const option = document.createElement('option');
+                option.value = branch;
+                option.textContent = branch;
+                branchColumnFilter.appendChild(option);
+            });
+            if (currentColumnValue && sortedBranches.includes(currentColumnValue)) {
+                branchColumnFilter.value = currentColumnValue;
+            } else {
+                branchColumnFilter.value = '';
+            }
+        }
 
         applyFiltersAndDisplay();
       }, (err) => console.error("Error en onSnapshot:", err));
     }
 
-    async function uploadPhoto(file, position) {
-      if (!storage || !currentUserId) throw new Error("Storage o usuario no disponibles");
-      const ext = (file.name.split('.').pop() || 'jpg').toLowerCase();
-      const fileName = `${currentUserId}_${position}_${Date.now()}.${ext}`;
-      const storageRef = ref(storage, `tire_photos/${currentUserId}/${fileName}`);
-      await uploadBytes(storageRef, file);
-      return getDownloadURL(storageRef);
+    async function convertImageFileToDataUrl(file) {
+      if (!(file instanceof File)) {
+        throw new Error('Archivo inválido.');
+      }
+
+      if (!file.type.startsWith('image/')) {
+        throw new Error('Solo se permiten imágenes.');
+      }
+
+      const maxDimension = 1280;
+      const objectUrl = URL.createObjectURL(file);
+
+      try {
+        const image = await new Promise((resolve, reject) => {
+          const img = new Image();
+          img.onload = () => resolve(img);
+          img.onerror = () => reject(new Error('No se pudo cargar la imagen.'));
+          img.src = objectUrl;
+        });
+
+        let { width, height } = image;
+        if (width > maxDimension || height > maxDimension) {
+          const ratio = Math.min(maxDimension / width, maxDimension / height);
+          width = Math.round(width * ratio);
+          height = Math.round(height * ratio);
+        }
+
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          throw new Error('No se pudo preparar el lienzo para la imagen.');
+        }
+        ctx.drawImage(image, 0, 0, width, height);
+
+        const mimeType = file.type === 'image/png' ? 'image/png' : 'image/jpeg';
+        const quality = mimeType === 'image/jpeg' ? 0.82 : undefined;
+        return canvas.toDataURL(mimeType, quality);
+      } finally {
+        URL.revokeObjectURL(objectUrl);
+      }
     }
     
     // === LÓGICA DE LA APLICACIÓN ===
@@ -208,14 +937,23 @@
       saveBtn.innerHTML = getLoaderSvg('Guardando...');
 
       try {
-        const uploadedPhotos = await Promise.all((data.photoFiles || []).map(async item => ({
-          position: item.position,
-          url: await uploadPhoto(item.file, item.position)
-        })));
-        
+        const processedPhotos = await Promise.all((data.photoFiles || []).map(async item => {
+          try {
+            const dataUrl = await convertImageFileToDataUrl(item.file);
+            return { position: item.position, dataUrl };
+          } catch (conversionError) {
+            console.error(`No se pudo procesar la imagen (${item.position}):`, conversionError);
+            return { position: item.position, dataUrl: null };
+          }
+        }));
+
+        if (processedPhotos.some(photo => !photo.dataUrl)) {
+          displayAppMessage('⚠️ Algunas fotografías no pudieron procesarse y se omitieron.', 'warning');
+        }
+
         data.tires = data.tires.map(tire => {
-          const foundPhoto = uploadedPhotos.find(p => p.position === tire.position);
-          return { ...tire, photoURL: foundPhoto ? foundPhoto.url : 'N/A' };
+          const foundPhoto = processedPhotos.find(p => p.position === tire.position);
+          return { ...tire, photoURL: foundPhoto && foundPhoto.dataUrl ? foundPhoto.dataUrl : 'N/A' };
         });
 
         const { photoFiles, ...finalRecord } = { ...data, timestamp: serverTimestamp() };
@@ -247,10 +985,15 @@
       const recordDetails = formatRecordForPrompt(record);
       const systemPrompt = "Actúa como ingeniero de mantenimiento de flotas y experto en neumáticos. Analiza el informe de surcos. Indica neumáticos críticos (<3mm) y sugiere un plan de acción conciso y priorizado (rotación, reemplazo, alineación, presión). Usa fuentes web si es útil y lista las citas.";
       const userQuery = `Análisis de la Orden N° ${record.orderNumber} con ${record.mileage} km:\n\n${recordDetails}`;
+      if (!apiKey) {
+        console.error('No se ha configurado la clave de API de Gemini.');
+        return displayAppMessage('Configura la clave de Gemini antes de usar el análisis con IA.', 'error');
+      }
+
       const payload = {
-        contents: [{ parts: [{ text: userQuery }] }],
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        tools: [{ "google_search": {} }]
+        contents: [{ role: 'user', parts: [{ text: userQuery }] }],
+        systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
+        tools: [{ google_search: {} }]
       };
 
       try {
@@ -259,13 +1002,15 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
-        if (!res.ok) throw new Error(`Gemini API request failed with status ${res.status}`);
-
         const result = await res.json();
+        if (!res.ok) {
+          const apiError = result?.error?.message;
+          throw new Error(apiError ? `Gemini API error: ${apiError}` : `Gemini API request failed with status ${res.status}`);
+        }
         const candidate = result?.candidates?.[0];
         const text = candidate?.content?.parts?.[0]?.text || 'No se pudo generar un análisis.';
         const sources = (candidate?.groundingMetadata?.groundingAttributions || []).map(a => ({ uri: a?.web?.uri, title: a?.web?.title })).filter(s => s.uri && s.title);
-        
+
         displayAppMessage(`✅ Análisis de Orden N° ${record.orderNumber} generado.`, 'success');
         console.log(`--- Análisis Gemini Orden N° ${record.orderNumber} ---`);
         console.log(text);
@@ -277,13 +1022,14 @@
 
       } catch (e) {
         console.error("Error en el análisis con Gemini:", e);
-        displayAppMessage('Error al conectar con la IA.', 'error');
+        const friendlyMessage = e?.message?.startsWith('Gemini API') ? e.message : 'Error al conectar con la IA.';
+        displayAppMessage(friendlyMessage, 'error');
       }
     }
 
     // === GENERACIÓN DE PDF ===
-    const logoBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAFeCAYAAABukM3AAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAE9YSURBVHhe7d15fFTV9f/xT5MkARIssEk2WCCybYVdtgq27f4vuIKKBYQLgoJll1244CIIKC44KuiuKCAqKgoKuOAsCKIiKAgKuy2AbLdlQRDZJrBNsEmYJJn+/midmUxyM3fnzklO8v28Pp/JJTfnzM15SXbu3DlzT/f09MTm5ma/u19+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn-girdim';
-
+    const logoBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABREAAAJaCAMAAAH448CaAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACTUExURX/Eyy+fqgCJlx+XpF+1vg+QnY/L0T+msW+8xE+ut/zSd/vAQfu3J/zJXPu7NPzNavzET8yuPJ2mUY2jWNyxNW2dZj6Ue+u0LryrQ06XdKypSn2gX16abS6Rgg+MkB+PiT+lrR+Piy+bnj6YhT+ckz+goD+kqm6ng721YQ+Ol16olty5TA+NlAyOnBmVoc/p6wAAADMT4LwAAAAxdFJOU////////////////////////////////////////////////////////////////wAfmk4hAAAACXBIWXMAAA7DAAAOwwHHb6hkAABggUlEQVR4Xu39h4LcthJFi/bEnrE1tiVb8tgj2/e9m7P+/+suwgaJHEiQDXbvdY41RKEAgsViITD06cf4sI19YBv7wDb2gW3sw9W38fn+HlubsqaN9wJsbsriNr7u1EDBwjbu1j7Jojben83GqOd6btio/ija9TptGntuS2Mbbcvt5pNtbby/f8GW2Mbf7Wlpo+N++zWxoY3uBbLbiRbUttG7hPdsYmUbvRYKAf7uQk0bRbc3XSqf1L+7NrGmjbMRPwnkX5kWUlDv0gsp70C0Qm/IFk5m1M2zUBnbUGqj2btq4KdPPymZ/E9yOqs/MzK3P4U2ui2EGcEz/s7ohnY/99kK/Rb+opIFdEMlEKwm00a/hTCia8wM3RqabqOuHs2TKKktMOiMKPBYpBaSaqMegaERGiXHdpbQJVRDF/tpoqA69DfsU/OmMpCoQKlbiEmkAskGMgeHfQFtHLn1/u3bx7vc+Ia9Wvwj5T6qJFBa2K4l2cbfsAPNh6q7kr9RyAa1KqQONqtItRFVf35/j1hL8js0XP5G7sxn5ATNfMJmmWgbZY3f9S4Uf8kdiJCtdlXL78IlPt7fP/xjxD5UO7FVINZG4XK6OoXaocmIofMUP0OUA6qaqmZG2vjpE1onMCLz1+I3yDJA0wFZM+VWhm2cmoj05Yn641hNjLfxx4+ngZqYauNQHKqNoQMO45NWG/0WDdlGr0njtTFo0zBN9Npot8rq9WWOm5nH0p237rzasaHQ9ad2YLXRrnpOqMLAJM/e2qjYvUalXqxtoa//Jmp36w9nmgq7jU41WD+RRVVaIhMzENpSpMU/r3ZCYbIVk7K1lSTVRqsO/VcxK8i5lN7y94Gk+0dg64nNKWWJEzhtnOuZK3SrsFPYdhV88ZxrtVFuPd3fzYk8bhvnmu2qJ2RSSy0VZBimhFrZf5K5NlJo/6vLG7TEJ2ijU96uQV0nL/IkaVS2Qqfh8O6OdBaA7DTvQ/5/QmXGiLbRnmy4ZcV4SFZ39iuUQoFsgHvNz8XNFlQ1wtjuDmJ4bVQlRFmkBNZOxH+ycU62hbqMnNYrZWxPW7JpYvvBCCwN/PUJ26hqmJkSakP9Y90SdlSFER2J3Lx/QMJkBGWN4HHK8PHbKIrMtUhw3iGd6jV/1R+gpJNI68ynXmdYJbC6AomV4RNrI7aAEEhMCn8cpiSy7oTDosRcm9wSYqQkk4pCbUscHUnQRqHizc5lBY/Ynn1G93jTHiTI8RLYUFtzSoGkrS6Cpt/TRtr47NbTjddIvV6bNUGTwjaOB9vYB7axD2xjH9jGPrCNfWAb+8A2doFN7AGb2AM2sQdsYg+uvYnRiXt3VjTRXifZksVN3Kd5kmVN3K15kiVNnBs4qC8+TC2U97OwuSXNTZyb9bTT6W5somW3u30a2NhE58Tu1cKmJjondrcWNjTR9byd/FBS20Tvic/9GljbRD+67NnCqiZaDdSPjfp3Ibal3MTT3ELzeJ1IWzd3lWhDik0UbdC3juYnAGWjdOtmpHwjSk3E3s0zuEomUM161I94z2zjAPkmYq9oX+QpSge0GKlu5JqIhwjRPIFKFpiddLqPuJJME7U90DoBnpCvaqhAP9djXolcQbKJfgM//azEtgT8qjOi6HO/rp2pJqoW/opGKOof9leKNo+ynYuvpUQTfRMKlBzbNSh9C2XPJRdT2hcdE5o9yq2P+28f8uH4z9ipjcz30SU1SqnxvCebiPqBqrqS7yhjg0oVUgebVSSaiJo/vb8nXpX49gc0XMI3F5AhQNUSmYHNMtEmygpV/QDVqx3V8v7x7fvHe/i6xXTVyAQ280SaKOpXlWn+VTtUGb+oTR+VpXHf90kAXU1NK8MmOi9zQKT/uGaELMNP0LRB1syj93xLSKyJTvMuT8wXx2ph/HKp85G9SDRxJI7UxPDU3punYC+MaWJ4gQxzyVhW9Fo0SgstXxRNsofyQZMvhnW5uG2yUrK1gvoxaez5RyHEhkRUhy2Jrj/1Eq4llmNjbAqQUGWBSQbPRCqpwE7piiehtbgrmeVKGUDkYbfcVjLbTkmZmIBM7lugJ34yrf/g6e+zPbLBhsDo6neDp4eE4zjGnQraW/grcV4ZwKawvfpreNFpZFtDbEtPbppk+XU6p4nT6nWsrQorhU03f0pPD8ZP2Zai3DTJ4FHeAKeJU41OEydUUoutqkWGEwmcv7rgjCrj1IQMhZb4uE1EQUtbl5UgOa02qLREJ+PvY+g8yXy56A15xqQTIlsgpTGCJgpNW90rqeqK1DaJA31sTJtaE4jjilTmEWmi/G9i3lYbMunkWyi5V9ZKYlNoScUpa9awSjp4TdQ1YFvhnkH1r1WrtwLutensJuW/8wtk2PDTIeUmOjXpP5OKo6qe4p9jiMqzFPRmIJjkc4aH38RAV6QVJmX+RtE5+mt1WhP6ginTAINKVYnallq2jqTYRN17YNsqLqUioVaUNHbGFOzmyuSWWzfKKH0l0NryLRWboIlWpX2J1Ou2WKAdv9jE4WATe8Am9oBN7AGb2AM2sQdsYg/YxBuBVuwBrdgDWrEHtGIPaMUe0Io9oBV7QCv2gFbswaWsqBa4t1qz3p1LWBG3EYsPix2Hfa0o31e4Hg+c2c+Kof3mX5k5OvtYURgwuH6lVa/FLbe3or6KPXshNPZ6mePSbGxFbSwkJqQNF78VMSIbWlE/TIaEzSiPl/ZjKyvqX9tAwuFqgqHFJlZMWlBlYeua6G7FjAV1Jjaviq5WVBbMmOk6TSjoZsWSBa/Yhr2sGDeh+66VeRpT66pnuU/BQ+wHpYMVtVmcj/9Pv/uDtEDbGLoxjmzQ1VbUJkBCAPNpIBMUjWjTLczsxboGq2PGtmdACeSCaZiNTw5kht2YMQIIB2e5Fd1jhN1skLOC6X0GiyGn3susKP1lLgmrOSCrG/ixFpuB7LnAivIIzOtS8Ze2kamJyNxfJVxmcdtPO3w/Yx2tVlStxjaMEKA/gqGBaBl2RXlUswQX6ujbrCgbik0caAxoSCDpRNmqypQzkG5OixXnCwdHFcX61dean4tM8Dn+sZEA7CkEdlRsfmtiQVxE++Po37UMfop6OfEPkURQO46glzkFG9qy1YpocsBfaGob/+gf4f30/vvHt8Rvy2aYf07WBg31QZltLvIWK6KZnz59QYtqwK8Vr+EPVNXE/xJ1PWT2tmWlFXE8/6IRHn8h24r+kFSDYhJIVvD+/vE1cG2v+1YjpV5DziorqqappgRMhhMaTheqymSBYj1VXxSKgfIxxCFgaw0VVlQN0TabqL799IYRdv3Qbxlvk4kX7Gm1IWt8UTQNxlNc0fM1vajvXWDD3UayR6LeiiQNrdiDZVbEd14I8K2oPkpRsFH0+aWbxreimQAjGaVC5cYIr2jYKG2kUv4NEouLeTNlM3enMa5v1PB4KzKW8rMepx+zd0BuG/pBM4nfLIgFEGikIFh1CNUmolmJVTzkVpE4l8mKvAydNDjzQsh8or/8jzwX5Al0errTAqlApoIj8HRmVIYASYX1VSUJpK0krwhVafxhbHtfqr/GtoNSVJzFyfZu4UFHA5kjtVPKetjWR41tFMX2RFQoUGI5BvFWd4Sk8O3CIkkrxhqjRK7M+X6Wj7xCsTmjLiBsS3IVSNx8x6Txsq6KQQqlNMgMBAtIW3Ha70QgEEREP8RFi2s7kqmPEpsKWUV6hUPmYlPhpP1MAQa8AEJb0xEL/DSIyZJkrKjqn+OYSvl1a2GEOXvehcqQeDaDNHow0texGaJLpYCSxE7Kk2gdtcyKgew6clbUe9Cb6jKJxA8llkqPsapkjlYwJFeXkQ8gVOJ00NLX7vn07HiOU14g0zNO0srVugvJWlGPAeSW2ojtKSHWIFP+qV+VVNoSk1DSEFOzTll4wvhABpkCN7WMrBUxDsCBQeYSyZglU6b2ZLVpE5MBFJBDAEgcdO68AxtXqMag2AaupJRfQ96KqkIAiY+X5aj6224d7qDFB5lRnUmYz5WI7fDuhqOhBmHYlshk663rghV1pQKkIszZastvEbYEOneOjJipuJHy8WT0rEqtaIDrEylrc0bIzFFF8wWOXCaQUpvREnmKVtQ159SUggEy4AvmKZ7CmzjYzLaFYMZui0hia8bIlLLaCnHzVApAJJFerLxS7DH/GFXZimof2EwhvyMeqymxb9GvYstCPpUSnR4KHp6UD0Z6qMhTYkJRCfPNlvVZ+TJx9nYvLmytIa4P9TdJhRUPR/GkV6I+hyz/SCNlK71GK+4PrdgDWrEHtGIPaMUe0Io9oBV7QCv2gFbsAa3YA1qxB7RiD2jFHtCKHaARO0AjdoBG7ACN2AEasQM0YgdoxA7QiB2gETtAI3aARuwAjdgBGrEDNGIHaMQO0IgdoBE7QCN2gEbswMWM6D39e2guZET9rguNuAZtQhpxBddlQcHuRtQGvPjXi7uyrxGVAS8UhjdkzyOSFsTmdbGbEeUradi8OnYyYuQtXGHV6veiB2cfI0a8UF7b1+KaexgxZi8luxYrbm/EqLW0kJ5YR9xaMdmB2daIeooc9B/XZcJtjai/PRD9Ngy2roQNjahMGDHX1dlwOyPiAzEh12fDzYyYMqHIwMYVsY0Rk18KvEY/3MaIyoTxiu+u0YYbGFF9aTH1WZmrdMTuRpQWTBvqOm3Y2Yh5E16rDbsasWBCkY+Na6OfEfUUL1Pf1dqwnxGVCbNmulob9jJiwoT2j0hdzTp2SBcj6pUG//OP8lelfsX2fDHj839yv6eX84Y/XbgjPYyozeL64U/ShI4j4k+E8OObB6ODEWEKpBTaggKkJ0eEbgyVf0xWGzF8NAn2k0AiKNpQ0+tHC/dlrRH1sSMhgfk0kAk1dcmqSXWZtT8RsDsrjagOenYf2M4AqSBwxNPpDB9OoUocg1VGdA/2F5huAnIb86VeJGPgg8aaY1zeK4yofkEB24ETCpCxDGVCMPwAc7kR3aOD4SyQsYJoCEXeUCw1ojgcK/7DbjbIWc0RLLnMiO6BwGwOyOqGEyk1yBmAJUaU3eo0X4PRXJCn8dNrcXwTssuywIh227XNfJCpCUWYEhogbcP5ID9kF6PZiHarYQUf5CogKgDlRsRY07rKIbwErUa0mwsLBCBbAslCUEkZdXNMgvTONBrRaigONAIUJJCsBtXlUEZUnJYE+jW07U+0EHOI3E/9aw0JBL1ArWm8PnyvNbYmI87NwlFFgYoEkq78grqTuJbcY+K4yPN/xfFEgY4EkiV8vf+CrSy/YU8Bzu/nQLYZS4yIA4gDHQkkn/74+HZ//+3rx/s7BJ8+/sXh5fkM9RJv2KGP9fuIkGxDuxGzbggbyh/96cN31FtG7zkEFW1px2Yjoskx/vgHze3Nvx+TD+dBG33MDytvtRzUaEQ0NuAdzWzkm7bO+/vHx7fmM/BV7dkHDfUxc8VNbi82GfFnNNTwLvj4QPOqgNXq+FxRdcySif7bjMiR7EiDEdFEgegnavmnxWoJvqKuFv4n/5fQFMYfOw8gq42IA/oTzQiQIxKtqVqvtTfg8/vH92/fvn18fHzRF0LpjAZHiF/ybgxkOSqr0geQinx/6Gw7HkFSizVIyff+VUjTBrZ1j1T7JBJrqTKibprabcg8mLNjEUQ1xEd5b7mJZROoMER12theRY0RVVPiw+PvUFE62FSoMllSI+Qky10UFUSQlzY2V1BhROUS2mYuznDBb2pwA3UCCuuo9VOoZ+hgxbIRVVtgtgnkFTEX5Vuz3zUyG7V9T3epX1StZYkRkUEMFZezvDBhPgXEZKKmY5HAgILaEjdEtUkufBtjaFr8yv+9eAJ4cXaARuwAjdgBGrEDy4zIDsbBN6IayWA7hX7YGgkSGlHZp2CgGp2bIm7EvIUqVG6LhBFzJipr3BpBx1I2UVnj1giMWLZRKf/2CI1YsqLOvd6XlxcQMWLBitnMEYgdEtio4bE94mEqpDziec5z6Fu0VD8hhcREdF9Clrg5L9VTbVN5E21396OnDTUh5eJnJZ7/Qm4bKBv5NhHkfr2hBKrY9ohmJZ5gQ24Vcd9P1+Pl6GSIzp2fDzwLMpeZAIoTECsg0kCm8NOSQGkC68pIAS0LQXYViSNLVqTkk7Or1AykCogCkO2CPAdkCfQ0c3IYSCVeUuHrTJgKkNRABhZ2lyn3UHVi20KJZ7l5ZTn8NNh0NyEkuEEJucS6tJApsFLpnJmoUBBtLGTrBhtZIwZtCaXylkGsDsuID6/3Z/OYpQY6AEJb6nwe3slzFd0UiAqxmzBTdYnYXkrKiLq7RcKgZK4wEBie7h/DTPNoG5KKQOAhs+dXAGRqer1VVYftmajQ6Mp/3RcKAkE7KSOqvXmN0e6EBAglFtFMKbSlUSULN1+m5qSbB6LCSernxk9EG0kj6uY650hJsG2QouSPq0T0BZ40qjMTaltpL1OTFKpnh/xcFYWxvZS0EYMn+FTa319EJDsOLYtkCjypTEa0DCLTjvqusp3Sp/Lk9mhKJpiDrCMWSCP6/aIwSuormlHSRvR3p5L27iXOOzc2KnfamNHdLxIaJQkUQZBjJ1W5HNDTHbPe9D1PJmMgu4qMEXX92EbKP0FKGGHOFYbWCUsZaQOk0YYnxApVJg20JHbSzcp7QSVFIxoFlQiq1lKbJ0tHpkMVZFogQ+O2SAiwFaL1PfTlDA3gSExCTxlkyqf540Y5I+o9WJvh8WhxJEOBTBvkBCDbAKkSYzOCzpVmT4dNv2onOee+/Hj58bj058cqjai2YocjpOkqRKYd58+FtRGoafS8Rm6pjSjxXE8oleJM2WpjBWUjyqOJdAcgJVcgT+pUN9RMzrQV5YYSB0hxPNcTSqWAeeopB7/YXEzWiNMoR/2NjuuhYCNKYcvkSaWWlir9acda5qHk8twibeEJZRVAHIEYK8ot5AnclCZWa46sEXUD0Iz4HF3mYBNYkmlLysKGRYUaMyYR/0b3q3PlSdZpC08oUr6OI5InwjOCkLS9Apg34nRtCSDyCHJkEMQmDhVbQQ0x2YzIE46TUDHiWK5rRKNp48oCjUBQJG9EVaEGAh9pM7u/cFStbSmPNDbZH6rxm9YJuiMp1FWZvzbONT5p2kjh7N+eijUur6ZgxGkJC+kQJ9NTDbKcC8fO9Zg7MvPXQoq0YSOZrjCq4IllIpWqpGBEXWmuWitbbdqqImVNcXT2/TSmM2mH83zeYobCDTGkZCa2Zqx8W9XByZAJnVJbiSI5SkZExUjE0AoTkCpE0u4WrE8yBISZKKQTYh50vsfroVbUFwlszUxBWemqrQAnxw78AkilkvxHbaTqAeuNmPlql7gqsQWgZfDTFigggGAGcomb0kwdi9RNxVyZh01vD5AJ5LZKm/+SFI2od4HtOEpDgvRERDQrqwPUwc9HaxocH/XaG2uZ0DJ/I7kamTdnTq1w+jCZr1YC7k+nzLRMUDZiTXclL9vItD1yA0vhN0kmn6WtdDLkSV3Jd2G+vdxhQD3iT3R6oJH1WWXF5fTjeZ7GKMSFIv9R/1mqEcpGFPvLNGZAHOukca0YQUYbY8SX7Oi7wohHo86GgmAA6iKquZOWhCEztV6hEfeHRuwAjdgBGrEDNGIHaMQO0IgdoBE7QCN2gEbsAI3YARqxAzRiB2jEDtCIHaARO0AjdoBG7ACN2AEasQM0YgdoxA7QiB2gETtAI3aARuwAjdgBGpGMAT2RjAE9kYwBPZGMAT2RjAE9kYwBPZGMAT2RjAE9kYwBPZGMAT2RjAE9kYwBPZGMAT2RjAE9kYwBPZGMAT2RjAE9kYwBPZGMwS16ovkmNJJkCG7NE+GEEkjIGNySJ5rP7oOmn+YjW3Mznuj9TEPjb/+QzbkFT3R/JXLpj/ORbbluT7R/hYRBcGyu1hOn3/+8pZHwkbnG8yR/pYo+eDSu7WxhTFj60R8BNskgXJUnKics/iyZ1uLAcTCuxhMrb5yYnlsS/8VqchmuwhOtZZrI71haeIuKdMWBOL4nwqs0kMWx/RAiMgzH9kS4lcb7UVyfyQ+P9fO2N8NxPXFaMBTk+2QJfkmf/fGwHNQTtV8papwLA0mkyIgc0RO1WykgKaBUC0uM5MIczhOVVynKXbJG6hbGkOTyHMsT59kvBGWkMtewD8BxPHFek4agBuW67JePwDE8cX66q2kJhhOVAzG+J849cu3A0IBiSJGxGdsT4UsSSOrRxbiAeBTG9UTtSYoF7z6dZTneTTkQY3qi8j8AURuiHKPhsRjPE1U0AwtnvXKCg01yFAbzRO2AGohyfMJfF1F27OEviTDSKdMOqChOk3/9pEDKQRTHlgGv3NM9R2aYs6OdBUAW5xfthBJIHNzi9jPaCfgtiCEYwxPtZ1hzN+fggAZIbR4dz0KF1fC24OUYwBPdsJWIUD/B+WzekGchpjvzww6uf7fxwK58Zy5ucJx5DWQuP8PxfH5CvsWDXQXqXA177124rCfiSWpFrCXwuShQsREREVsCVNsVLpVvxwU90Vo4jLQC/pbiF6jZnJ31x1jf3ORJp0d7adODvXdvLmVQnFABBBZwthzQrMN8N3HdfCTplmc+htuDS3jiNEVB2sZaokkD3UuRCZUOnIm3sLsn4ixFpwFwtAJQHgDvI7VpOL4ss6snmmCCpAPcrMTPUB+NF/ul1wz0yRT7eSJOReQRmdQyTUDKDd/iM5hLc3rN9eP0SZd9PHE6I0hPxBasE6BEBCjUuePbW2RBfB9SfsnvLUt28MRp0RDpCfhPFSgSQQTECMLh1Mp3PDdEVbUT6Xvht+yTW3viFAe8Rw3hALWk4hiy+5EMmL/OY4gtxqq+d97ejZ1tPRFm9cMhzmgLKOnS0Ldvza9o0kqs7+8ZbsUnt/REmHK9GyYcsWrtcX9+Q/PWUFgfusaVyu08EUZDCuBktYLSLsgbmtWh8tm+NR9wTd8U2MoTY49d4+w0Ex+XIfN4LJ28p5eEWl8EH5KtZywTOA3tJJZmkNuZ94+/vgk+Pj7+fn9/h1Dz/h3nXfDvZwj7EHm+LUtkNCk59sx7H0+ExReQGnR9+vP974+v3/7FSbgMX9DIfuDoaomtBx11xXwHT4SRlyDi4Sl3n2IMvv2O5vYDpqslnOAc7/mgrT0Rlm3gz49vsOY18K/u6z9EX/8nDrCBxnuYvkMeagFoS0+svp+s+P0/2G8z/v32XQz/sLsm/nwXY4GP79+6XiNfqwebbVMcfxQJ8ehs5Ynxtb4/to53MgB5M42N+eNL70MSUfQvHUW9A2ma2PjPBg3fXW/giUEo/GzNOlezPLDtw/u78KK+wTPO02uVc9k/LCwYdz7T2RNxOsCXtqntv87IHzW6IG9LrNVL617zfoiRwDJXPhfO5cl6s2fAFciOnvgbTCn5s82Sf4WjeVTqgcwtKMwOoDUgqnmn0+l8Pjs3ZJKe+Ty55EgRspsnwiyCzzjMOmQcnAdAugYB0gHI7kLfBxXfLnkbHG1owvTbSF6aTp4Ig4hhEg6vgvgFqatBIoLOX8Qvrfcy+vC2cR+/7t62io8jLPd08USYRAwMlYsVWH/Y2FuRvkGvO2/2eKadTg+iScRZwdbl6OGJsMynT9kJCpTJqFx4FtPDE6feBz4XcntPIJNWus1YFHA8H+QSkqavJ8a/RoMsQjL09kQFPFADGSFZNvFEQpqhJ5IxoCeSMaAnkjGgJ5IxKHqifrxj/Y/gTU+20/dJjJJfwH0kkCzCeQkNMkIsCp4I39GsiGbOs+yQEWLR4onLfch9qQJCQiwaemfJwuc1UBpASIhFuceF+xggbQJFNZAR4lAz9nP71vYvpqGgZsVgk1wzdY6xapyHUopr+szaAThSD1QbouBJAMIqUEQBUYZ5IPp8Ogt9UeZgj9k29Bnn2oVaYbrX08II0Gw+K1qczqJ94hTs8Th3dWeJ49JAVgWKSCDxUXlVH2K6yIcMxH6xVcR/OjP7Fqc5YiTTPEOxye5zoZpS+r0qpV1gs16tYdiGpiiqL3zoK8Lrv/pHngwop9B3f5DoSaZV2eAAHZd0SIJC8RCs79xAUgNKSPLOA6VqUKw7LRMINEVR6YrQVoTnBBkp9OhUKupYgwpij4VHeXpo/rYlSmaBqgcyo0DFA5nlcwu1li7B+0oTpBGgkEeGdnEyhOE3HCm1eKJzfFVtsr9JAJEFMmzKtUKxgbqhWLV/R88rcgQ6LS9UCCTRJiCv/CnY2ewQFPH7WYhDIkd9d6FvOTV5ousHEGWAogIiB2RJar+LAfV2UD4OdBysjvhBeAukEkgtphOK9ATE0d1PDoZ0GuhVB0Voi24ZG+ldWK5Yd8VuRqMn2iekYEFryJxRrR62G6A/kT45UJiAOMRdo8qNqoRmGLXnkwmBBTKioxnktPQDSBeAstLGZrZkhcoOtHqiE88higIVBUQxoNFkBuUstS5sjygg8kBmWxsscj9XjRwBBBbIqNgtFKtaCE2Bm1SpKFCoqXxLmj3RiXUQhVQpCaCywAxmgotkFqgmZr46b/HqhC6eCM7z1wshsEBGxRFAsUZ1iu9Il/cyjSmRvhTtnmgZJtl6q7/LDwChtMAMZjKEZAGtG/fEaVqFdBuFL24hN5aPjIrdQlH14/kYjwx7zAdJ8jbrkT1xNm+i+ciTFGYipq/XKSg/3Z/PT3eiZc+P0kyTqQRaQRFK4synLjUgs09uc2xEMaRCdHZkmDg/PHwWzH807qcQEwQnzzWnBqJkE91LGqfgQbTm4UG2Wv32gz2S1gr9WeSJdsyDxMI+sQVHhFY1KKaIiBxOr+7JzE0NoTJTnkUA6CNVD8ot5hQezjSC94wOaaKNyKxmsxt/yzzR9jZIJqwPO5fiC9QqkE7l2UBnyN2rv2KYdnKCm0tpicK+6jX6xCI7hdJZ/XxSPZnDgEakySm5BHkVSAuVrLiGhZ5oTaEhAImuNA70otydBBlfhprYCTYSNF3Dsd980kDBw7g+kg2gYITzyXTSk3/rZHo3wkWmK+kp6IZS16fKnM9jyIM8BQ9bep/NUk+0TAmBAiIFRFkaVH1MUfwNWWhC4f9JvAsjt35TBEVrykIzFXmR3Ypb+uI/+rfYE2NDRaQVEBWA8gKnQcngZx6QvZ4XZ2neAvkC0wEg2QbK1hTOayK3BZRUQLTsIDqy2BNtA2iBHUu0pAzUy/p3fi/rFURSAklHUPGEuXCQbNmj6g3VVoMbFzSRnSI7vWw4CPms4oYs90TLANJLsKmoXwlBgbwZMJZBCmiZJYRAAkmBx+qb3cAeUykBrr3qiTbaqM+ouXBVIk9W07RKnIRXdUTPYYNyXm/KIxkHY02kNmGFJ9rn3gHZNbiLWXHipooIrVUbSJJAraWpGpTTS3kNziSBtlF3Uxlyu0FWqRoo5arIXU8tN7SWssYTZzPYtNWIQsljnLwL6Ym4GFIJJFGg0hLOJnRBHfb1dtUZgqY1NUAaqQyZ0KtzKuqAYkwTOclKzIVQc5QrWOWJs3lnkFMNikXLIUsAgUUqw5rAJDtf5NcPIiZQcvInpApHHR+phZIEqf6zyUWgGgsUyIlWgyzBAms1sc4TrYYqFiwFTJ7j+02hr0V2pP3WeU88l7BkGfDRHiXOjUU6XVXyWRDUV7EorhV9V0j2FgmgHVNHTrCEYa1EQrIhKz1xul4Viy4bay0c5d2lWC0LyWVP0WJGicX/LQd3ufsRXkcJZVvRMgAkBn9FGeKZhDhA63mKEFYUN6BAzPeRI4Az2r82GSlxOuEKPxn/kYvgU2IRaz3ROogWqzigdBSoRNDBNPmgbMQZ+4D6JyDOA12XTJaD1rMUZzdpmv2jTGyXyIgCFRsjFedA/RUS7UhR7TpWe6Id0xaM/zUo71KoTSshkSAZAFW5ZmdNnXdkJ4BSiB5GIJFD6VmKOt3eB01ROlIQOS6pW6UiTKrm3Iv/aUbwROsgkF6E5dCSslMrNWwXUcqCkzj7Ye8kOiXkB1SfbOjbFMsqLWznUHqzSXRykblRMhwSSrzhRGYhW+xbHp1ogWmELtJ6adj08ERzfEitoEtrro/AvK93FROdKNa73JAsQRa+//EgQubkierUram0z7lPjtZIF9Z6jo+sbs2Zl40RPi23kLJ654UtZRQ6Asmfr78i6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQM6IlkDOiJZAzoiWQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAjoiGQI6IhkCOiIZAhu0BEf7zVIkiG4OUd8gBve30FAhuDGHPEMLxRAQsbgphzxGT6oeISQDMEtOSI80AApGYLbcUSrV9a8IoOMwK044gneZ+BUZTBuwxE9N+TwcDxuwRHhfuAZUjIUV++IcD/FE51wWK7aEe3lGg4Kx+aKHXG6h3J/hoSMy7U64gt8kE54EK7TEc2aIb3wMFyjIz5pL3xCkhyB63NE7YWFtcIX/CWjcG2OCDdEKsGr0OCi9lhclyOiU0YqRZUS2ZdrckSs1yCVYrrdhzQZgutxRMyUSzdP5tVFLnGPxLU4oolzpQUbqCkgIiNwJY4I16ocHhogJANwFY4Iv5JAkgBKBkjJAFyBI2KqrMgvYkNJ83Q9w+Nr4PBnY558CKr9kPf+RuPgjui+iAJhAigJICADcWhHNN9sUDxAmAJqdMMxObAjOi+iFI8DenTDQTmuI8KxFBBlqFYkl+GojgjHUkCUQyuWem9yOY7piPZUueYItCYSZEQO6YjarxRVT3NpVSTIkBzQEe+0X0nq+lqtiwQZk+M5onYrBSQF1J0XPgc7OEdzRGvNBpISMoDy9ZXhOZgjzveVaxsuF73ph+NzLEfUPiio/qSc+tgDtsnAHMkRlQtKGp6tlup8Ze8AHMcRp165ZVlaFcA2GZmjOOLkhk3jPV0ECTIyx3BE7VASCOrQRfiS1BE4giNqf5JAUMmiQuQyDO+I7QuHBpRiQDwEgzui9ehr670R3AmkHx6DoR3RehGg+QkufCCRHys+CAM7ovVww4JxnirGBxAPw7COaD9yCFELS8uRCzGoI9pv5y1poizHGypHYkhHtN/OWzTZkL06NskxGNARnbfzIGtkcUFyKcZzRO2AGohaESX5IOzBGM0R7Q/ZLB3kiTr4BOLRGMsRp19HEVQsvfz8CRsO8hFEbJLDMJQjag/UQJTmp0+fPr1h26GmMBmNgRzRXrKBKI3wQgESDg/ht7700ji/ADYy4ziichYAUYrftBvGHdEvbo8678+45Xc6nc4CnSADMIojOh/2giwBnFACiY1XXFeYgx/sHIJBzgKcQpObpsADNZDZnNwZM2osU/02FtmGMRwR3gAgDJm6ZACxjVtc11eN6bjJ/ozgiPZjNpklQHjfzK/IsBATHmv1ETW2wa76IgxgdTgAgNDnFzifDbJsnAp0hctgV70zl3dEnHlNvDm/wvNcIgHxoZcfathV78elHVH+UOhEfDkFfheAbBu7Y1ffeOjAEx8n24MLO6K9yBedLMe6ZA0UbDoHRBt21RtzWUfEWZbE5ijyLl6KX6Bjs36mkueOXfVmXNIRCy+lwOMSQMlGTJmxJXBuqEzgjgpSy2BXvQUXdEScV0EkGv4Mf0sBNQfHnaPOhrw6Tue4Myt4d7AzF3PE+SSHY8Ncl6yBokfQc9qPlQkgbeQx6Y93Fx5hXxMXMuX8OkD4KHUpGAp+gmoVzyY4Ir2MU9Id2VX34DKOiFMY8403+FqOJj8EXQ407Y3sqldyCUc0ZzP2gh5cLcsSP+yI198noW+2sL8jmrlybM/wtDwX9kONsxCfgSs+leztiOa5QyQd/Idr4kB5BGqXgeiNZXZ2RJwZpBzKU2UFtMeB3tiFXR0RpyQ2zayZo0igPhrTzLwAvTHFjo6IcxELhxUrNhroj0p2DXyC3hhhN0c0c5TISYCTlYF+QCbrgsi7iTjoCPRGl50ccVrARnqmOhimfU1nx56CGIRkx/2w8xB9YPaxBOwePkylfaiG31AiZH5sFoIsb2/Rt/J3ILUaTm+U7GGE6ZubSE/Af2pAiRjQUCTDYnYytOPKZGr98ea9cYfjh6mDZ2zSz7yGZKIYNFx+RuD7tbLn/1lVtRPJkeMte+Pmhz5Z3Xu6oW712oBCAW21ZNl3jKkfjIx11jfqjVsfNawbdMs4+7WglA9yO5IMvVbfvkVP7r5Se4PvtG58wLCr3y3jjNaDcj7IvQRoQUeChyluyhs3PdbpMnfvpcTfDs2Ckh7IHID0nL4N+7cUNLfijVse5jQCQhrg3DWBoi61twV3o8/CUOiM908vYkyJ7Ctlw8MzfujOUpZ5Dwq7IG80Ii/+N5O/dX2NTzpu54gwWodweCw/1HSYgxcewL2yNxQ2c0TEQ/cp7IWdafysInNk1g8dne9GBlyRM27liHqe4vUhOD3NoLgL8g7A6qFjzhtjHyY4Ihs54nPkal08t0B5lwVT7zH4eaFfniKTGHANgXEjR4xUi/PQDsp7IHNnvny7v//2JxLrafbJZ2/he+LwP0u92RjRY3kAQwUeLTeq6/n898c3wdePj4/39/c/INX8/g/OueA7ZH1odceUNyL7mOzkiDD5AlCBD3In3t8/vn77V4QrgXCjL8KPkDPx/l2Es258Ra29aJ1mxx8qQ+YB2cURV4znUIOP8jwRvWD/y/BXvz4atMbGyHLjUScvezgirLwE1KDIP3p/Gf77gob2o3XJJ5xSH/J3+7d3xDXTW9G+4Xwv5GswClhLqzMGg8bjzV02d0SYtpW//4JJD4MYmobj0hU0dtPOr1xLDvZDwRs74oLJ7ft3WPIqwOTp78jkqYLGJx/9lUaID8Gmjlj58YaZDzHv3Q3hIb/PSzSfhasIj/kuHAf52/GtYWTZ2Et7nfRxhotbOiJMWccOgVDGpmW9p3bSvj7a4I2wZyXeus5BPkO/nSPCiCnEuVX8/vHx1Voq7so/vcdtM+8fctVyNdXe2NRJ+7/scYTh4laOCPt5vG/mc5p/v30XwzHsbB/eP/7Dzjvxnx5V/i4uUuwCNC15+8+QDT+N3sQRI+9wfv66zfDPHehdjL+3vcAm/sf/+XyuPmX+yteWw7DVbNA4nJuZLz3P0vKB3i6IOPbx8dcet3zqHNJ7Zmfc+y69HdF/1utLY8f134dxMlQomRqJrEOhXFM9S6H7XIkcHCvEtpinr7pQaxzSiY1jvmjQ1xFdN/yzcSL812cUlKBGF+RtivXKyeInKNcgvfP7At8sOqTtjeNNX3o6onszr9EL/ekj6nTZ2DMS04H6D5Zth4ief4vwKYJqqYu5yz4mO397Z7Alxo6OCJMpvuBoKwkXMRI+gdwtyC+QjOCMcdStwNPp9OL9tFvaISdnHGnE2M8RYRdJ21A9+pQpKvVBbmd+aXgD9Ke3t4v02BlaH2UUTCuNw/TRvRzRupvX5Ib//OncxUIVSdsiuwtLXx6J8+sl3XPRx8xwB2aQuUsnR5y/yvW7Prwq/v3fUHwGtSAVgvw1rH/Hs8jb7j35srf6tS8OcROwkyPCHJ8+1S9bxwcoOrIiEaH5OQqLrhGwmp82DpXrPu2o78AgcUn6OCJs8umTOqwKMnecRC3YiqN31MRlPDDGW8cPOgq6BHd5PrB5QXo44nzJKycr8LD6Ldzak/nzjp8kXsK6UNnxI7ditt1rrrCYDg2AYQSlJa7eL4L7M9if3956fAHpcogDwqFY7PL1+Ysv5fR0xD/hb1EO8ljc7fJ42Qd0ejriB3wuwsFeoCC702NsAD/M9MxQJCRFl0Eq1lS+wu0CoEZIki6OaIDf+bBfJkW6OqL/3g5AJiFp+jpi8NqOBFmEZOjsiAK438RRvwpEdqW/I/o/fAghITm2cESJeUbzGn+JgWzAVo5ISBN0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBDs6ovpA2iF/A4RsT8kR8TjN+kcKdT0CpAmxKTkivGe1/6AWCSSEWBQc0XrSddXjC6hDwefCSEjBEeE7ijXdM6rQQEbITIMjrnEg1KCBjJCZFkdc/ga2+y4LhITMtDjichdCcQAhITNtjrj04zUoruFD2ySk4Ij+DwFD3AhfYiElCo4YvKkMcRsoq+HXmEiEkiP6MXHJIqD7sjOEhNgUHdHrV5f4EUpqICPEoeyI6+e8KKiBjBCHGkdctwz4iGIaCAlxqXJEN6Y1PsmFUhrIyC48HcjedY7oelPbTWcUUvT+iDbJoH654hmJ4al0RPdXfyGswumZIUtj2e10vnsRc/aXoy33NHQYNRaRKNOdG8ObGU8hWc/sEqfH81mcwLtaL1lD7S5wVBrIqkARBURpXH/3uFg4bbgUTmirBKIkUKu4gw/NJrvP43oIKnF+WNJnw0+u1jri4rVA+8Ag8pFZ/sJ5HBTYFRHSqxdP0UxDPjhCqXxQk22QrgJFBBBkUYpV5wAFulMddJ1WQlaBvR4eO58n97ddC6DQHkTOSukmOdRsckM0qBQPCmoCCKpAEUGxJ2k6BVsFxfre32ktZEWcQAqZRV0cnEExjZJs8eMg/g12i9xJjR8MMkOmXrw0qISaAIIa7KE5RHGyo6EIW81+GoahaImi9gkaqCvCgIiMapwaILO5O2u6PUseIXXkyaiS6tcnR6wPtBDUgBKK3MiiNRS0tKGJBke0B+KV7dG/fQkgmyldjNP7p+LyFlHqQbc19pnuOK3zTH/xPU78tCIzSjxqT+ZEOgnUBBBUgAIAwgjOCYqgLy+hKKwuTsHTdrOVBkd0jq6uHJQVEFkgIw50Ahov4frFlOqBEvQdnBP65FcVPX3VjjjbCeky0Dekxy9QiLPrMkWLIxb8KgJ0JZDYIMfGHHtyJNI6pBFUHaIT7vNE6ps9b+5nbd+EyAV5DY5YOyAKLAtxCPJtNlyiydHkiI4bQJQDmgqIbJADHmpqjFmuTPkEQtEnGiUjy4rIEUCggUwAgQOyyoc9Wb16Zgb9CYhDkA+eLngjps0R7YaXOz27F43tx45CEBWBejP56xxKDlaLRcIamUJog5xg/Dg9Qoe0A7IqDh2KtVaCslA3ZyDtX1CQQHIhljtiseG2H6YmbtP5RboI1F1eVei6O4l/k113LppAZSLhtfqAwkOZLqhwH8iIXrXI2s4R3c0U9WPVTWl0RHvgU+jwoKVILyBAobrTCTpLyEP82XWxDSA3RBfZ2LLQxQSRPSAnVqzeAaYruu5kQVldTtjM7gQa5XZsSqMjzkdW6puhpMj0i1oh7SQhUh9/JFoY5WzH5PSFg2xB/RTbBoWjTUFOLG+K3Uinma7+qmksdHW92MzupKyxB62OOB9avul26My4GTSarKCfskPBYkmoSSDxQW5lvAlB8Wj1yIplIqPm2KFYM2ueV0JVEtu5nZg+Zunhd6J593bfCFEMaCggigGNipPhg4LlktYlAYmL6SKXrpqZyIakC/JiucaQFWEYmjW+As2pF0Iq8+4kFA7niPOh5q5QKCggigKVsjsFoGBNyeneMdIucAik2tHFExUgL5Y7XdFIZ4BiTRuhOanmj12C/H2Xr0MWXAdouASSAHtwBlEc6FTZ2AXlKnqrub9C0gV5LcNUG3Oo8ZCDzNiu6x0RejVGgqKlinS6LPJrat+SBY5ovV+amoUgWwJJAigtuBxRsMoRjTJSHshc+OY/CifsiNzYrhdGROvRoPDaQYZtz+xSpgTZ9QsX27BkZICWSyDxmGycnTBLoFU6GaKV4v8v9ulGwZr2TwN4pD3mdfVCY2OYwkj6ZNZJkVE4Ark2miIsiQzHpyBLmhjZdafgVHnlt1NzIgPQdAEELvYzLBClgJb2gGd9A+Dx/uF8vj+LxMlbgLFrQ2RAKoPWk0AQgGwNZLWgVDKa4gCQstEZAvnwmvgjDvo838zL+N8MapqIXhWQJY8MuciGP9w/yVMgPe8sDW3dJhjKEWf3iE357JWbQncHrWpQTKElpfZrLQUkId5Jh7SOYhl5HrFp4y+3L8A/9DmyQ6CBLNVG71IvgmLdWeSI1umFwAY5CogSQKkelJNg7JOeY/gvIUAcwxp3AWQUgXqzFasCXoan18wAEWkAYeKYwkMvgHLdWeaI1nwFkhkrr9RqaFWDYgqIlOzk9xeR84ycOOHpqBy6QxupelY5YuLiQ27QGIjjjUReNVv1zAsd0Wp/0PlCLoEkCdQqcWfW8B3hMMrzxcl5PmUub5RKEekp1bioMH0xxZCsZ+5G25Cj6ESboBG2BfK1jij78AWzuVoWOqJ1yiExlG5kWNSdDbEr6DsgV5wZbKWpMl+6MY9pG0GjeKQBDY5oBU8UjgKViBLkU4a1WWE8SeIUdGWhI1oHAAGAUJIevhmgGOUkyL10ArVzqZdLP4oXcrKHFQ75KLQgUKBkyNOrWSuYJoLm2k6dK5E1GyHsO5Hhk81UPIpT8Ng+/l1GZ0eETAFRhnmdR5le2vBZnNTXVO9jg9neU9aUzY/TZDr3yLhxcc9sjQVkpeqyk3et8/6OVACyozwkL1TsCymcAmUwcR5e0i9rbMRif1eNV0AggURRUzNUl5xJuIyzWOQCxVZEEEgCFQOkSyLiVLhm9A9VpHwy7c2B0sZPkbwYXR2xYcKsQVhbYoWpJDYmxCRDRNRFdc5YK7g+0JBAsmxXKFvhiGZAiaSHsWETKCvIV74fHRxx7rEgkNTduDXhDMkWppLYAMhdzznljFZ3DwlSjaBwhSPmg9aCgOiM3iFD6mJ0cMTpGJCUlCcqGqgj1YJTEgmJFvQjXNiZjw0CpOqYRv8oXOGI0EztB7kVRPeFvGWPfPRjsSNaY2BIkFJAVALa5UHWORhy6oLGtFb/tGjAliWYS0Numo9UDbojVJtqq2ooDc3UfpBbAQo4TJZDOsnjtr662BGt49chAgmFElQA9eIhSh1sGlQ56zTqtKQ2Gjfx7AzFsLaOlE7UoLtR3bmrzarC0EyopmbFMg/GgCS6lDVdZUinkMe/3FnKrKhbt18iEs5IRefXgAJ539E63uKJFlrN1wIFJAXuGhd37E5aS5xEBTCSTujtmsLQTFytyJUV6dpewzqhEj1g5OUbUqOzji6O+OSuvyG/BpTIFjF1I6mBzG4+RIJy74z4hlQt8/0QpxNQ2xWY4KNTSFQ8EgzN+MoeMvONgE5UCVlVFSC1BSsc0XK+pX5YZYWoCoRO8yETlI5qai/S1UyuqFLYrqzF7BSRDSmdyALNmCpyIovtDlDKVoFkFKj0H37PrHDE+fAcKqaBMyiTswI0vIZi4ceVapkEghTQKupFsAtiu24UP60GIe2mckAzZlhkVR8wkjYVK9rQyDv7Svo7IjLrKC4kIj8wAsKL13x76Q+iGPPEA4IG7ILYrqlmHkNDYBygvmtGysYcCJJpjGIspiEreTUhv+YoV7DGEecmWiCrFpRKFJvu3wWzGcj9KGHf8IMoAhSWmNY99UiU65mmtvN8AZcSUjm0YkTTdPZI5oBmTBU5qVqQW7WXFfR2xMaZ6FRFbCQ+B67QCMkOBXIJJCGl/CSzn+s0EqWqoCSwzAMJUjlSmpBXHQdUY8qmG4mdOmsJFZKtWOWIloVB8zMb06lF2gIZAggcklnIUEDkozMrOkWbs/0mlzlpSObPEnQEECgiogQJTRMP64ZuUI7tDzmRkzcPdaqGwWtY54iWjRWQtoCSYVmIBRC4pPOQo4gHaGS2rHyf7U7f2i3S6SNPDltjsjhxTUirahBAOea2yAlrgliw6TxFsdIRbTMLIG1hvjFgNQUSTTxyIRMpB7dRwt38d1r+b2Qpsu54fnx2xp0AuQIIEksbLyZqKSAEiK8VJ0AresVr74hMQD2mjxxnyO0YcXs/XOuI8zFIIGsDZSVa8Dz7piA16IShkPKwOlEDctLPqvwQPucRPvCgQbYCIgEEE95FmphvVQxmtKJbf1u/LKkaBJmr3jkFYQn5GK+/oZ7tXU5PR2zp6mbm2xUxoBQCJ0EqQOc2Iw4h4sQu7nAJQo26vSbPuP9txlg7rQcg8ig9O1ppgQKSGlAi2znHiOrr60fkqr+T4y5zAclaR3SOAaJGcmceKjEKCjq7P34XHOm4Q2Jr0WgitnMovfjIBYIqUCRWyA2ALrFpihA7f0UF6k/kNnctqx3R7oAgagWlQ7L9jlZBIoZWSFGIxHHuIh1p7iRqUmFC5yKRQevNZ2peU4GgEhSKFUsGg3jb719UHbJXUmnjiD8Sl1wFqx3RPt+QNIPiHshMoXTyzU9HKzXyxHY1yX4H+XHSN2hVdkVnpvSsUzy5PtLVoFisoDOrmkiZ9/6H6pvvxYhbCyZHrBjyxlnviFZkgWQBqMACGWmUVvm4oxZG3umcnrv4VETnCNkAoVWQyKD1ZkWkWxdCBSgogMACGRbIiHAvOkL1xyid1eu/wtY6uYD1jpg9unpQhQHSNNVDfYnxN+l44TQ8N8yrvcK9KbKiWFZpYTuDUrMUkV4wMUBJAQQO5fmVQeSJ/z/bjqhovzQmOjjidHhILkWdS9GRne9qjuf8JL+aVs2dtl0F8r1+BdK1nO7PDy/TuTxXnRShiK0cusZJE9cNUm3MA9roiEF1HyKKPxZqF9niMhOHaJqhuubHSzsier/N7wLdKsFK1elu8ZxAV6WAZAmirOibxb+OI4qQqhKL6OGIKqYv6ChIJcpvVkQbBzPnTt0pqEE6nJo5u444JRfQxRHJtqiQiO0eqEEQthchC6sxsKxG/jfNmsWcblnVdMQjIPym78Bncdeuka4mR92BI8rOmY54vbwuXp47DHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdEQyBHREMgR0RDIEdERCCDEwIhJCiIERkRBCDIyIhBBiYEQkhBADIyIhhBgYEQkhxMCISAghBkZEQggxMCISQoiBEZEQQgyMiIQQYmBEJIQQAyMiIYQYGBEJIcTAiEgIIQZGREIIMTAiEkKIgRGREEIMjIiEEGJgRCSEEAMjIiGEGBgRCSHEwIhICCEGRkRCCDEwIhJCiIERkRBCDIyIhBBiYEQkhBADIyIhhBgYEQkhxMCISAghBkZEQggxMCISQoiBEZEQQgyMiIQQYmBEJIQQAyMiIYQYGBFvhNPd/cwDhIQQF0bE6+cBcXCCJ52QBLw4rpsgGgqQRQgJYES8Xh4RAX2QTQgJYES8UuxlQx+oEEJ8GBGvkSeEvhRQI4R4MCJeGydEvSRPj9AkhPgwIl4Tp/zg8PUZeoSQOIyI18Irwl6MuxcoEUKyMCIen8f0yPDM80tIC7xijkxqXPjApUJCFsGIeEzizxqeOTsmZBWMiIcjMjDk5JiQPvBSOhJnRMCJV2QQQrrAiHgUvDeU7/gkDSH9YUQ8AN6i4RniBfB0E5KFl8jguNHwYc3IUI4yn3jCCcnAC2RgXnQYBCuGhoL5mUUICCEhjIiD4r6Qty4aemuQd5ASQnwYEUfEuae8MhqGN6g5TCQkBSPiaHi3USBdTPwNP96oJiQKI+JQBPFrXehKf/2BL7cQEoMRcRgis9t1Q8TcZ7Tv+eYzIREYEYcg9ZnXFacn/UEcDSfOhIQwIl6edOyCwgKSdd7xjBOShtfHZcnMbFc8JBONhw9cOySkBCPi5YguHCrW/RRKJB5y1ZCQKhgRL4P7OorN2uAVxENGQ0KqYUTcn+fUIt/D+rPhVb326W5CbgxGxJ3xPuo18YD8Vbirkvx4IiGtMCLuSGqq3CUaes9jc65MyAIYEfci9f5IrzNgv/3XKcQScnMwIu5C4gnsjst8qFHCb9sQshRGxB2I3kl56vnSyLwHfhKWkBXw+tma6K2UvveAp13wXgoh62BE3JTYKyldB4cCs48npAkhi2FE3I7YvZTut4CnGypIE0JWwIi4EZFX9LZ4XBpVc4BISBcYETfA/Y0UxTbPw8z7gYAQsgpGxM5EouFWt3+tRUo+j01IFxgRO+L9RIpis1jlTMshI4SsgxGxE7FPe234MIwbfPk9bEL6wIi4nufYI4fbvjiCnQCeREI6wYtpHbGJ8ubvjbhLlbzNTEg3GBGXE/8G9uafJHQfc+QXEAnpCCPiMuLRsPfrKDGwKwXDISF9YURsJ/HR112egOEnHQjZEl5WbSSi4U5redMnZ/kBREI2gRGxnvhMeccvzpgBIpKEkN4wItYRvacs2PFGL5rAW8uEbAcjYgWJqfK+nyPEAJEPYxOyIYyIBVK/FrXHbWUbvVf+YAAhm8KImCP2wVdJn6defsLfCrCEiRQhZCMYEZOkbiv3GBy+fZIgUUbPmPn0ISFbw4gYx31RbqJDUPpZBUMJBGX0vpEghGwHI2LIcyIcrn0E+6dfEAo1v0BcAiuZSMWIfJPx/umV92AIaYYR0ScRDtc99fIroqANskroJcTkI9mpx4LquHulAxBiwQvCIfWczYonbX5DAPT5FfkFdIBODE9Td36WcH7hoJIQRsSZXHyBShvzkmHIz9ApkNu7zuvP05leQW4V+j7Izj6bVxC9JcMIUCygd4+Ei87aGM6qyY1Bh1ekFg8ljeFQP1hTAsoF1P6jC5gqZ1fOj5xVk+uHETH9BQdB2zdmcrNkFxQooJoQe00l9SLNPnBWTa6Xm/ftZ1zmERoGh+VZsgNKFVCNiN3R6XlDZR0PnFWT6+LGHToZW+oHh7EHa/JUPoio2hE7P7kp/uW446yaXAG3HBFXf+Er9WBNnjeULqCagm2H9BNCg/B0fkFTCTkaNxsRT7h8PWq/1V+/ZOiDCkrIxkQHquseyd6ZBy45kmNxmw4bf0/vqWrh8CdEtmX8hlpKyPbER1qqqVXkD+ekeDlrUARIyatWAEpp1ej07pHBkYzPDXpp9EbtQ80iWN2DNTlQURHRxtzc/fRaDk7Nz1AuQATUJVGSs2oyLLcWEWNP2tR80Gb5LNkCdXUlERwv8WnZ02PmOaY4fJCHDMZNOWQYOx5qjn/90FDR8IHYZZzMgO3yX9o+nZtviPP1GDICN+OFwVz5qWrq1ika7hAPB+X0uuxhoQe1cjmtZqI2QjbmNlzNHxxWrrEte7omxq3GQ4vnx84PlnM1kmzA9UdEb22r+tHrLiuHGtRINC/Ny40F+HA46cZ1R0Tv49LV62vd5soS1ElCXtqXG/MwNpKVXHFEdKfKtY9er3ze0Kf2pwNundNr54EjYyNZxJVGRO/FjtrBYdexoaDyO9nE5fTYc+zI2EgauMKI6L+QUvf7ee0fbChR+f6y4ZfmEjfD80m/NBN98rIBxkZS5Noiov/Wb83osO88WVH5mwEWKMiw2MySF2f4FTOS4Kocw78wyh+xafyuYR2ouwW/GQyLS6l5wdGGsZE4XI07hN+yKc2Qei8aalB5GyjrsSYs/vpWEevfNChybbQ+5MPYSATX4QRhOCw8g73BRFmB6tvIPvlYF6/eeoT3K32M/PkVPlENY+MNcwWnPvxdgMLiYcdnrz2wgwa2a8tCaj9XdjxOC57vYWy8OY5+wsMvHeYXD/vfUrZonH9uNVDtwm89RoxyTv7zUR5BOj3mHvlhbLwRjn2aQxfOzpa3HpC1RcThhocZfnvLx7W3t4p3wLsE2e0pfZqCXzC7ag58csPP62dnyzsEoKZnbra4y30YflG3dEa+qVOz+sjYeIUc9pQGH1LJzpb3CT8tFziKkJC3gcaSz3UfM2NsvBoOeiJ9Nx0gHAqwvxpQguT5eZhR5Mvib5k9nc+vfFfmMBwyIsLVDNkPfO04OW24TYsSpIExho4Lvg4+88DQODwHjIiuR44xOpTUB8Rtng2/IYYYOq75zOMdv3Y7KoeLiE48zH7ia+dbF9hrBUe6yTw+lx86rvg6OCPjcBwsIuL+8l1x8rFzOGyZMe/dtNvBPPr4VnhWaDsWfgK37M9kL44VEcWosOYnUnaPOS3fhUWRm+Hzl9//wOYQ/Pa2y6jytGDg+Iqy5IIccB2xwP5DsKbvZKPMtfP++9dvuM41f/2NnNHYfE2ydVJd1emTrbiyiHiBGWlTPNz5xb0/39/ff/8wfP/27Rs24/yt/3wVet/+wfWZ51+pKtAFP95//54t99/XoYaLPlsHx6bYyAHjZbimiHiJBbq2DyNEXnUTMeuLiCV/1cYgGzcc/S2qEnUtqGdn/vs+6nhxYusXDh8rP+LI8eLuXE1EvMj9isp4KL+K/3g+/w//P/g5kfwz1vpinLYer5nnqu/bPvGO9H5cR0S8SDj05sun0+u5949t3gL/ff/9Mww6MJtHRlgjwwPj4h5cQUTcPxz+ISanX7/9/+GppBP//PXx+/vg0XHjlcbyW9RcXtyYg0fE/e5U/PH+8d29e0r2AaulX/Vq6Re5Wvr+fukJ97aRsbTM+MDnFzfjyBGx4pN8a/n8JX/z9CpAyEHqevhPH9dfMo5uNPTc9Enwl3xc5F2XTThsRNx0rvzn397TdAdHxgY5xhKDq3WhQQ/QzBM9f+mQ8x/2cgC+fd0iNv6y5Z3pUz4u1vz8LmngkBFxoxeD/3z/ctxAKCKTGgyJePUnjmcE/kD8HC5wbhAb23+ku57CnRcOF7txuIjYHA3/fH/XDycfaSwTo9tAbwT+eP9bhsl/cWyXBk+ayz5FIsfBgmVdy3a3pUvTaN516cCRImL1r0b9edS7ILgoRxvo7YB8tPyQPdY/OpZ+16EU931kj7VZYCx9u5ZP6aziIBGxJhiKODjMmCPJVQ30NsGM6K/ujtbT+fXU8x5x6du1/DrtIsaPiMUHbD7/vvl48F8RxfTbdoL/9axI9tQi7/V0Eoa9uYHePojORL6ALd++PnTU7Bchs+9Lc8jYxtgRMf+x6c8f214R3z7+jjz2Vr9+jgLkSHyWs17V98mB6q5zjvNZ9qPrSA4cnzhkrGPciJi5hfLnl79wnjfhn6/v2FEMNK+CK/jxgIoHkd9u75PgKmp6jyDBd3qyLkKeztH7MHdjj4Euz6D2ST5t+MfHluvvf30pznPRwCpQ5IAsui3w62VeLz8K8kGkOZDqONoUSO/OL0su19gPrPLp7iQjRsTEhfX5+4ZzmP8qP8SCJtaBMkdi/dtp/FmtdmpWYk4avYitxn+NETJ8doc/ZhBhuIgYv5HyvuHNk/nrzj+/vRXeDEQjK9n5+7CL+O1iv0ki+fVNwcFl45eHl/Ps34Q5I4NoBouIsYD051ecu+789/Wz8MTMsAgtmIC4mtHGSz+P8ZvH9YhoiabfBBt/WcfCHTDyVcCZsSIiHMPiz20Gh//7/4E9lkAzNJC1gJKX4qIDwC25vlD5tl84nLDeDXziDFozUkQM504fOF0daV5TRlM+fVo2vNp55jzEb7tfkoOFygFO1zSN5khRMk5EDB35O85UF55elx+qmMuvGmttuUx2iaHFIRlrufLnsZYvzAd2kLxlxoiIseXDv/U5WsX5caAx8E+l2zZFxEWNukhXfhKW7TO2NDeqcMvIf1bT/Mb+kLzIp3Ru/msRQ0SM2FvLKybMfDyfkIW8PNw/YPM2GWMMhShosXCE+DTQmJAQcjhGjYhLbjFzZZgQso5hxlSIhIb2iMgnTQkhaxlrljmvbv+f/xcCXS2ogRBCljPuutsJoa6KJxQihJAVDH0n4ox4V+S2744RQnoxdEQUnPJfTtfwF3cIIV0YPSIqCj/NCC1CCFnJISKiJvEbZMglhJDVHCgiTpwez/rXJM584oYQ0pMjRkRCCNkGRkRCCDEwIhJCiIERkRBCDIyIhBBiYEQkhBADIyIhhBgYEQkhxHCtEVF+JOLp3Pq7e4SQ26ZDRHx+PUteRgmuj/J1lhlGRUJILWvDGMLOxKXjT+xTOS/II4SQPOsiYvSrrhf8WGHq02EcJxJCalgVEZ8RcHwu9UXr9Ge3oUAIITlWRcTk11wvFBIZEQkhq1gVERFuIlwkJGZ+mYU/aU8IqWCjiHiJmJj70jZUCCEkx2YRcf87LNhtDP4yFSGkhlUR0XvyLwBq+5D7NdNVR0kIuRlWxor4T59M7Pkk4AP2GYEP3xBCqlg9esr/euh+q4npVcQ7aBBCSIEO88n8OHGn31JOB2b+mDMhpJYuK2ypJ7UVu9zVSE+ZeVOFEFJNr3sOLwhAMTZfTczcVLnU6zOEkCPSKyJmw9LG93qxkwiMh+RqueNTtlvQM1YhDMWAxjZgHyHIJ+Tq0AvnSJB+dB295abO293xTT0VuccK4hOXKQ/Lua9Tyocdns5IbIt9G3GfPeZ5vKYHfjsfCk5TDGh0B9UHdLjHLGMtqnk+nc7n9F31p9OPF/nF7tPp9cyb212Rl78w7+ms7p49nc893lGfe9G7Xq+8oz4NZJsQPlax8fO2Yoem45f+LT9Pb2E35/WHyJdaL31O0yXoHdzD02XY6v5K4jZz24GdH9RXwE+m1OmcPpA6bmrwKAMMNjuSOQXr4pi/5A3xKlDVDOS98eKRBnmrEf3N+XG+Cp4fC29gFHk63teae0fE+BlTbDS+T1w3yK0j877Lcq78ts7p9BgZNN/1Gq+k/WhisYF9l4F4ObGFG2R1B9U7IGsluXujyznaWLF7RMw8sb1BiEDNIVXH9bxJJJzAXmI8movyUP4ijNowaFizeoAqiiwbiaPwDOSLQTUOyOoNavdA5jJyH41az9FGiRtExIw/I78byXNZcVipGzLdSEYEZ4jy4/nu/uGs2isGXSJEP4h5i1Ibhil8L2DJvYvcDboIzaPSyFgIOQtBJS7I60zqVCx2mRXntorDzZS2ufiSZkZ+J1BpSMXIC5o9eBIzPL3ub+F5gpxjAigsQi70SFDr1qgQvZama2LZBdp22YURce1IHdXYbPJsRWaEvswl1q4T2ghfeQjq4zoiSDl21/sNqau1whlXDRDvxGmW8U14QGx88uod5KoQmOVpq5uMnZtc38wVS1mooYJgJ6ujV2SuskFEzM9ul1zJKLoI5Xyyd75/eo30KC/Ra+MAbDVBS0WrjoPoxNvUVZ0ldOt4EkZ6lidexPlme6GODen8tM8WqwmougS0He7EsAPR5UGEVvnb4Mjx0Uo1oMDE+osgMgLoHhBK3RTUGmgbIcoL6/Hp/lVc2nvNUS7BVhFRkAiK3e4loD6PulEolDP0Gc02Loktp8/1d1o2aS1SF7QjDpPoQF/i7URuEb90hwscNVl0jxqliNh+KZenAgd8emYtG0bE5CdxkL0O1BWA7BLQjvDU8/Yv6tyNNePF1LA+wvw44Mvd/fn1VJrt1nkZlC2QESeMirUz1aCfgnwFEV9HTh9CA4cDPKg2kBkkdp55HIctI2Jy4WP9TlNjmYaRXTQAIK8bqHZHFntyeXgoRj2P6dcWH7FrKNtURapg/+UFlqBIpWMF5SBfQ+hOPWNKsJQhjeNH4SUrUtFL9KArgH3YNCImhx0rh2Gpi7fdJfyut7cvZL8cCZ4efzxak5PwjJz0jepyyNIsuTBK8VA/HtTENCWrmD5GZus1UTQshYw8wXirwwpJ6OmLTkOCICDqCyg4kKVXM4obejb9cGwbEZNjJGQvIbnyv+TunntNbeEJ1lrNqwhtfSZshfjVbIn47On19WnVDcP7c+UqVGT3yMkDXYuqxbsgkHRY8guX5JDRA7/y6fwiPQN5I94lBemNsnFETC3eLu+VU8FgSTz0WrfVl0t0FMQkyh9MaOkiEraVtC2Io5DDrkvq2OdE5cmEtg1yskB1psNFEE4GujlT4PFzLwXBzLLrCoXBoivpetg6IqbmjUsXWVA8ANltBIMFyPvzNLmZv0+IVxDtI1rsG5yiva8J7HaidlEF6jbIyRLMcCFfBaqa6XNloTIba9h+CjrFJetRKDqxeUwYmh2OPj6qWzRDTc2Ykd0KSs9AvinYlQHSlYQ2bpjuuqvrHRbV2vAXEurjcWSQjJwsfrEuRxzM/CFfRzieQIYB0okFI9PAioyIW5OY3SG3ART0QW47KD+zw+DIu3K6xZ/AyJBX4IZTCHcj6OUgryAY49cVDkzV4SSEfTUyVhEcYOCgwb1iyBsIL09k3Ca79AeJmTNya4n4vwS5S0ANFr3vNYdgR4aOS5eL18e9QVrXBzLLYK+gbecoZIGMLEEI6HBHrSIinuQzA6L3eZDf4Zy+QZgDNVkgwwY5E83rUWFE3HvVZCh2GiFHZ86NjohSHshcBKqY2GPC6IWfjhHRtXHTiQ1Oz35RETs0tPljMFWtMqe/jtilG/RN+CA/Nx11e0mN6/sjgJR3InsG8lpWzC6ukZ0iYvzJxJbuLLGEiNxldJzB2k/UyVdxJXHb6jxDl8gTecy28byilMvDDvebPb+AtBrvDNY1GMoTxYgoY4YTa59FtIt6dD2oKYMXqZJnFPkTrSNefwYH8SKsNssvQkk69vm7sFdEjD8cXx0PEvFwXUD0ffrhx4sUnV9Oqd21gd14uINECJcT9PCS9mkgCsbY0qXdU7Bk9oqigsp2+jdyLkJxXho8s54+umCg3OZUwWLUs7pW715Pp5VBX7NbhOnEfu2NLgNWjkKgHYDsRWx+ZSS83u2SV8zYHlMOuySwRK4rjy1+SsgN5wuXr0TwqJ5sdLnG11IM3ZFeLnOhhI6MjCqSE/teYD+HYc8IDhM5VF0F0PVZtf4THbP2JBWXkG1oOoiX6IjQZVE8lNTU3dddvGsZ0g2pOMQtqV2WgfpEaVUXahMNfRdKbAf2cxx2HdPCSA4VFzA0PVbeEEMtW/GQNGx06UsL3cGD/BqnuispfxGytitfHA8lxXGiRIzHXjv98AFqBCtPaA27R0T1FqTofJuOzT/XxcJ+715/cjYeM2/2SeMN2TUixsMQ8pJAzWXVlS9IPMqzBh3PigaFNlCiLo25kz+vqqpbRds1siqKefEJ0i3Z4KxnaH4ORhH2fcjI4JWpj0Mo0BE9Dt43rHRl56bDbA7IipJ4knHdhFnS6do4v7S6vee8yv7YXkznJb7nqrFiSOWtjQkUM0C6JR0j4pP8XePTyVjej2OttpgIAiLkGcKFxKeXaVLxYN0Ufwq6TGSs5OH0euAQ6LHzkcRu4iIrRuAeoEOry7eTH8z36x+nwUyHx1G8i1J2qdhcxOIrr4b2yPj0/PJQO270Ti6k25K8GYW/GvPgyP2d/wsip9P5HO9/UMIAaTUoluDh/Cp/0kJ9k+1ZO79siVmYbHw0wr56UlfYxJNZsXmYfpJx/l7wNbJzRIyu5KRmwMmbH8hfiX+9y3HnWfT8Oncz3B79cdna1oLvFS5CjIKK10yCQguD4Rrkm+OHj6lPcYf7L42XPWoDrR3VisFr+/lxzwyEhgdx3C+v8+D35tg7IkY7w/ioInGq164gzqBCA6Qb460DpBcG0vSzQD1L4nb2RzqCGLDbUWF/hk6jbNQGIKxk4SpFO+qSwk4N3pnddNJxBIaIiNHHBZDl07HvuogvYGdAxgxsRrl7VbfrTvNU9OGyLrvk5iSKunhDtVW3aNrAHg197OkdDqR1bHzDdyLRQSHXAOnNsntEjA82kDmz+QBRgkoNkG4L9gWU6OUs3xCIPzF+ifFgDU3vM8TCHbIMkG6CdxsOezT0iYiozABpJSjUH3WxqcXGzGKQ0pzZPSIMxv7HD8O7eNdMaqkY2Z3w97LL0gn2pfGuxng3MPyKTs296eCWPOQGSLuDfsb2Ly2Z6HMFoDIDpLWgVFdQdRnoG3YcrQ/JBXoEWN7FGdFD5tPhTq9NsIC3erSgI1q+mUrFEOwxvsJ+DCd9TP62vAZqwBtjQtoXu8uDSOC1EtKVoDIDpJUkJkSVaCcK6lDSCqA+A/lidP942MB6iTFydMKFvPQd5mXPu+bwL+A1DzmeTnO7syHR2WnM+sjyQOYxSJ1CZCtcnS0WB5wpgDXQHi0iBj2z8PQTht131stK57MUWp3o2elQ/c60+sqG/gTEizi9TO0ddb2nxCUiYrxPVD6bnH9t0uWg7gmIF4AKAIQx3Jl63PrIdOloANTYecjtEn9ox+pz3Au4vxu6hrY7Oy90dFmU8OqEtAq/XzaR5NzaQfshsXYI4Tdg+blwz/nwqz1xLhIR49f8YzoebtTfoPYJiNtBeZBrLVRAyvqlcLIQz779R90ukaiIHIF3/XYOz96ROmfEG5NtERGrLas+P+ewwhCoYaLyqvFH9ItDgncsjIgtwGiVbGVbf76y0Bu9yw/SONABaev7d30ktZ9OSRDOZXfwWW8AMh+wP6JZH+9ngp4VcgChps9+/aOBuAS0Z1Z1/ahjBvIS0J6AuBHvYlq9KH8pLhQRYxd8EpTZAL+HhriB4CmUwhXm+k3W+tGB4vLHESOLe7ucfCcmWq2HZAbylUQGpn6YcTUgXIcbEStXOPwOefWLSP5VVdmF+u1Y0FH6zrUqsl+WC0XEYPEizcqRUR7sw9C6WBdcfcXGQg8UwmdiFQG5jaCwzR79eHIAHURoyFcR9rQRB3d9r8sV4FZZ50aeZXq0wx+qVtrU9zOIawmvZWQckktFxOqQ2HM2FRJcQdX2eI3dMUdeBiiCcrSPB8UF03vP3vt04kGPYe82yFy5lvgccynkOSALQLgOb9eQ5vCOvtP5CPy5rtOD8kR1a6I23/aS3ZqLRcTYLC5k68X/8LKEPI8/z5DU/Xxd+2ejgxYq5Av5TaCcZofBYazD8CZk/tW05mRH3/iJh9jkqHUFqMsAaRr/pK7sDGaCCFUVngLr1QW12DnudiSX4nIRMXWtz2w6XzZgXzPlKc9zrOHIKwJ1AGEe6AY0/YSoe6lsOkTEPiJAYcLvFSFu5BT7xZm0caAA+vS5qMwAaQq/uT3Phl933Qw+HOohI0Ns+tK67DQgl4yI4bKHw05Nw94s0iOou3NiZFs/UXDnNZU9amY8/VR7SUPf8KR/reB87tWpn17OhV/sjFwu/iyvdfAa7Zwkmc7CHRD1iUaoDORPCZRmIO/EsvFeeObShnl5Svzo2RXEwwtHxFg4mtht+I39OUSGp+kPBbZdxiikqfeh5LVvIbSg7fISX42MU2/38DZGjvihxmJ99itiEzl7QCUFtDRd/Ax1AQij+EbbYNHNH/BVzbWiMS5im2Snt+m0Y0cuHBGjyz+SPe2LXQaIa+7p8VQY+DQb0I0BENax+Outjejd3M1PgzzKwaRDY0sypxMaPufkQCs7s/A/eh3HPgcQrQN1AQhd1EevfTZx89BAyMgSNg6IU30+zd+Rj1LTsytFbCvUWcC2xtvJDsvdIReOiOn5IPJ3oWUI5YIKmkBRRfMqVtu4bAzyl30ptt7VH3N9fEEBCSTrcDwoOuyLRhTkdQfVz9Rc5rHbhXXUzXQCVSXAtkYYyRjvWb0hXT+H6salI2Kyx0f2TmCnTdwttJ19gUPUROPwzOfp/8HGLlR088v7I4em+3AoI+ly0TnHAJkL8mw2HAJhDxbIyLLkTDxV//6AUBbTrVlbJYOIaF9UwtP3j08Xj4hRXxHs3LD8TZ6ANT9Ea0W0xdcEyrejHbJTEMrTcAabFjojNEc1lFPUXtFZUJciduDhEHFbB4/4M3KyNPa2Tf4r9GX9SAkffFIiGy8iioi5wTJrgZ0DTxRlXJ/91xCi85qQ9G/TV4J6JCuravwZUfyKm2a7oLhsbazS+iGLrhlrnN7H0VCZIlZjsBgN+XZEglvNodYODdrNLgrJf9B7iTk6RBZuRBQuusk6a54RImL0/tVlGhZricP6Pst2OYjWkVyKtXlK3Kk4LY5ELg9n+ZO9p/OawXNbWHxYdZPYOtGQrAN1aUIb+H61x6O2sT6v7uwUF24XBSpRTt1K1WNy1RYlsvDPf5fheyNDRMTIRb0+8iwmFWHOPx6bb4REmM56j8pcjCerb0yZR5Rrz7BqD+5mn59FbFNbcbY8OxUBvkc8mZ5y6HMsqEwTjMXcK/1pr4suYsrq9YXkcw0/nheOqmVZ1TfIxJ06iVo0I+wkT8dJOnDT+wcdGSMiBmP1C9xjclFB5eKtWMCd62OH5+VOBJjnl/OTGIVC1I1Tvx/ndgZkkdHrFBP7TNJrwU4dWkKNjKl1j4eWEVXpP+KyEv2RJZoQVjJnRO4Zm/sySER0lj0u1TsQshj4rmSPKXEt59iLRMjbGexYzZsR+fy2WBFRZV7CksNExB+P/+/z6XX1J+IIuQxzlw7BQJycz3hCuDdmz6IpD5h++Y1xIqKyKDZ3hBGIkC7IYCPpNMnsj4qKF7h7C8TOp415y/xVG25EVDNnmTbZu8CISEgX5HW78zLhoZhXba0NvTWFPH9hVytM2XvgtYAQQm4YRkRCCDEwIhJCiIERkRBCDIyIhBBiYEQkhBADIyIhhBgYEQkhxMCISAghBkZEQggxMCISQoiBEZEQQgyMiIQQYmBEJIQQAyMiIYQYGBEJIcTAiEgIIQZGREIIMTAiEkKIgRGREEIMjIiEEGJgRCSEEAMjIiGEGBgRCSHEwIhICCEGRkRCCDEwIhJCiIERkRBCDIyIhBBiYEQkhBADIyIhhBgYEQkhxMCISAghBkZEQggxMCISQoiBEZEQQgyMiIQQYmBEJIQQAyMiIYQYGBEJIcTAiEgIIQZGREIIMTAiEkKIgRGREEIMjIiEEGJgRCSEEAMjIiGEGBgRCSHEwIhICCEGRkRCCDEwIhJCiIERkRBCDIyIhBBiYEQkhBDNjx//H5BkbEfIO/BdAAAAAElFTkSuQmCC';
+    
     function generateRecommendations(record) {
         const recommendations = new Set();
         const replacementThreshold = 3.0;
@@ -313,7 +1059,7 @@
 
         recommendations.add('- Verificación de Presión: Es crucial revisar y ajustar la presión de todos los neumáticos semanalmente según las especificaciones del fabricante.');
 
-        if (recommendations.size === 1) { 
+        if (recommendations.size === 1 && !recommendations.has('- Planificar Rotación: Considere rotar los neumáticos para promover un desgaste uniforme en el próximo mantenimiento.')) { 
             return ['- Todos los neumáticos se encuentran en buen estado. Continuar con las revisiones periódicas de presión.'];
         }
 
@@ -389,7 +1135,6 @@
 
             yPos = doc.lastAutoTable.finalY + 10;
             
-            // Sección de Recomendaciones
             doc.setFontSize(14);
             doc.setFont('helvetica', 'bold');
             doc.text("Recomendaciones", 15, yPos);
@@ -413,7 +1158,7 @@
 
             const imageTires = record.tires.filter(t => t.photoURL && t.photoURL !== 'N/A');
             if (imageTires.length > 0) {
-                 if (yPos > 180) { // Check if there's enough space for the title and at least one image
+                 if (yPos > 180) { 
                     doc.addPage();
                     yPos = 20;
                 }
@@ -424,6 +1169,9 @@
                 
                 const imagePromises = imageTires.map(async (tire) => {
                     try {
+                        if (tire.photoURL.startsWith('data:')) {
+                            return { tire, imageBase64: tire.photoURL, status: 'fulfilled' };
+                        }
                         const response = await fetch(tire.photoURL);
                         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
                         const blob = await response.blob();
@@ -478,13 +1226,16 @@
 
         displayAppMessage('Generando Informe General...', 'info');
 
+        const { recordsWithKpi, categoryAverages } = calculateKpi(window.currentRecords);
+
         const latestRecordsMap = new Map();
-        window.currentRecords.forEach(record => {
+        recordsWithKpi.forEach(record => {
             if (!latestRecordsMap.has(record.orderNumber) || new Date(record.date) > new Date(latestRecordsMap.get(record.orderNumber).date)) {
                 latestRecordsMap.set(record.orderNumber, record);
             }
         });
-        const latestRecords = Array.from(latestRecordsMap.values()).sort((a, b) => a.orderNumber - b.orderNumber);
+        
+        const latestRecords = Array.from(latestRecordsMap.values()).sort((a, b) => compareOrderNumbers(a.orderNumber, b.orderNumber));
 
         const { jsPDF } = window.jspdf;
         const doc = new jsPDF();
@@ -508,28 +1259,44 @@
 
         const tableBody = latestRecords.map(record => {
             const minSurco = (record.tires || []).reduce((min, t) => Math.min(min, t.surco1, t.surco2, t.surco3), 99);
+            const kpmm = record.kpmm !== null ? `${record.kpmm.toLocaleString('es-CL')}` : 'N/A';
             return [
                 record.orderNumber,
                 record.vehicleType,
                 record.branchName,
                 new Date(record.date).toLocaleDateString('es-CL', { timeZone: 'UTC' }),
-                `${minSurco.toFixed(1)} mm`
+                `${minSurco.toFixed(1)} mm`,
+                kpmm
             ];
         });
 
         doc.autoTable({
             startY: 40,
-            head: [['N° Orden (Vehículo)', 'Tipo', 'Sucursal', 'Última Revisión', 'Surco Mínimo']],
+            head: [['N° Orden (Vehículo)', 'Tipo', 'Sucursal', 'Última Revisión', 'Surco Mínimo', 'Rendimiento (km/mm)']],
             body: tableBody,
             theme: 'grid',
             headStyles: { fillColor: [5, 150, 105] },
              didParseCell: function (data) {
+                const record = latestRecords[data.row.index];
+                if (!record) return;
+
                 if (data.column.index === 4) {
                     let value = parseFloat(data.cell.raw);
                     if (!isNaN(value) && value < 3.0) {
                         data.cell.styles.fillColor = '#FFDDE0';
                         data.cell.styles.textColor = '#900C3F';
                         data.cell.styles.fontStyle = 'bold';
+                    }
+                }
+                if (data.column.index === 5) {
+                    const kpmm = record.kpmm;
+                    if (kpmm !== null) {
+                        const avg = categoryAverages[record.vehicleType];
+                        if (avg) {
+                            if (kpmm > avg * 1.15) { data.cell.styles.fillColor = '#D4EDDA'; data.cell.styles.textColor = '#155724'; } 
+                            else if (kpmm < avg * 0.85) { data.cell.styles.fillColor = '#F8D7DA'; data.cell.styles.textColor = '#721C24'; }
+                            else { data.cell.styles.fillColor = '#FFF3CD'; data.cell.styles.textColor = '#856404'; }
+                        }
                     }
                 }
             }
@@ -540,6 +1307,63 @@
     }
     
     // === HELPERS Y UI ===
+    function calculateKpi(records) {
+        const recordsWithKpi = [];
+        const vehicleGroups = records.reduce((acc, record) => {
+            const key = record.orderNumber;
+            if (!acc[key]) acc[key] = [];
+            acc[key].push(record);
+            return acc;
+        }, {});
+
+        for (const orderNumber in vehicleGroups) {
+            const group = vehicleGroups[orderNumber].sort((a, b) => a.mileage - b.mileage);
+
+            for (let i = 0; i < group.length; i++) {
+                const currentRecord = { ...group[i] };
+                if (i > 0) {
+                    const prevRecord = group[i - 1];
+                    const kmDiff = currentRecord.mileage - prevRecord.mileage;
+
+                    const getAvgMinTread = (r) => {
+                        if (!r.tires || r.tires.length === 0) return 0;
+                        const minTreads = r.tires.map(t => Math.min(t.surco1, t.surco2, t.surco3));
+                        return minTreads.reduce((sum, val) => sum + val, 0) / minTreads.length;
+                    };
+
+                    const prevAvgTread = getAvgMinTread(prevRecord);
+                    const currentAvgTread = getAvgMinTread(currentRecord);
+                    const wearDiff = prevAvgTread - currentAvgTread;
+
+                    if (kmDiff > 0 && wearDiff > 0) {
+                        currentRecord.kpmm = Math.round(kmDiff / wearDiff);
+                    } else {
+                        currentRecord.kpmm = null;
+                    }
+                } else {
+                    currentRecord.kpmm = null;
+                }
+                recordsWithKpi.push(currentRecord);
+            }
+        }
+        
+        const categoryKpis = recordsWithKpi.reduce((acc, record) => {
+            if (record.kpmm !== null && record.vehicleType) {
+                if (!acc[record.vehicleType]) acc[record.vehicleType] = [];
+                acc[record.vehicleType].push(record.kpmm);
+            }
+            return acc;
+        }, {});
+
+        const categoryAverages = {};
+        for (const type in categoryKpis) {
+            const kpis = categoryKpis[type];
+            categoryAverages[type] = kpis.reduce((sum, val) => sum + val, 0) / kpis.length;
+        }
+
+        return { recordsWithKpi: recordsWithKpi.sort((a,b) => new Date(b.date) - new Date(a.date)), categoryAverages };
+    }
+
     function setUiState(state, message = '') {
       const errorEl = document.getElementById('firebaseErrorDisplay');
       const idEl = document.getElementById('userIdDisplay');
@@ -576,7 +1400,7 @@
     }
 
     window.switchTab = function(tabName) {
-      ['guide', 'register', 'records'].forEach(tab => {
+      ['guide', 'register', 'records', 'admin'].forEach(tab => {
         document.getElementById(`tab-button-${tab}`)?.classList.toggle('active', tab === tabName);
         document.getElementById(`tab-content-${tab}`)?.classList.toggle('hidden', tab !== tabName);
       });
@@ -586,6 +1410,9 @@
         const filter = document.getElementById('branchFilter');
         if (filter) filter.value = 'all';
         applyFiltersAndDisplay();
+      }
+      if (tabName === 'admin') {
+        renderCatalogLists();
       }
     }
 
@@ -600,6 +1427,8 @@
       if (reviewBtn) reviewBtn.disabled = true;
       const dateEl = document.getElementById('date');
       if (dateEl) dateEl.value = new Date().toISOString().slice(0, 10);
+      resetOrderAutofill();
+      refreshCatalogSelects();
     }
 
     window.generateTireInputs = function() {
@@ -607,6 +1436,7 @@
       const container = document.getElementById('tireInputsContainer');
       container.innerHTML = '';
       const positions = TIRES_STRUCTURE[vehicleType] || [];
+      const modelOptions = getMakeModelOptionsMarkup();
 
       positions.forEach((position, index) => {
         const positionDesc = getPositionDescription(position);
@@ -618,7 +1448,7 @@
               <label class="block text-xs font-medium text-gray-700 mb-1" for="tireMakeModel-${index}">Marca y Modelo (Específico)</label>
               <select id="tireMakeModel-${index}" name="tireMakeModel_${position}" class="form-control text-sm">
                 <option value="" selected>Usar marca general del formulario</option>
-                ${PREDEFINED_MODELS.map(m => `<option value="${m}">${m}</option>`).join('')}
+                ${modelOptions}
               </select>
             </div>
             <div class="grid grid-cols-3 gap-2 mb-4">
@@ -664,9 +1494,35 @@
             return;
         }
 
+        const orderInput = document.getElementById('orderNumber');
+        if (orderInput && !orderInput.checkValidity()) {
+            displayReview([{type: 'error', text: orderInput.validationMessage || 'Número de orden inválido.'}]);
+            finishReview(reviewBtn);
+            return;
+        }
+
+        const normalizedOrder = normalizeOrderKey(generalData.orderNumber);
+        if (!normalizedOrder) {
+            displayReview([{type: 'error', text: 'Ingresa un número de orden válido.'}]);
+            finishReview(reviewBtn);
+            return;
+        }
+
+        const matchedOrder = fleetLookup.get(normalizedOrder);
+        const orderDisplay = matchedOrder?.orderNumber || generalData.orderNumber.trim();
+        const vehiclePlate = generalData.vehiclePlate || matchedOrder?.plate || '';
+
+        const mileageValue = parseInt(generalData.mileage, 10);
+        if (!Number.isFinite(mileageValue)) {
+            displayReview([{type: 'error', text: 'El kilometraje debe ser un número válido.'}]);
+            finishReview(reviewBtn);
+            return;
+        }
+
         const data = {
-            orderNumber: parseInt(generalData.orderNumber),
-            mileage: parseInt(generalData.mileage),
+            orderNumber: orderDisplay,
+            orderNumberNormalized: normalizedOrder,
+            mileage: mileageValue,
             date: generalData.date,
             tireSize: generalData.tireSize,
             vehicleType: generalData.vehicleType,
@@ -674,6 +1530,7 @@
             generalComments: generalData.generalComments || '',
             technicianId: currentUserId,
             branchName: generalData.branchName,
+            vehiclePlate,
             tires: [],
             photoFiles: []
         };
@@ -781,36 +1638,220 @@
       document.getElementById('randomTip').innerHTML = tip;
     }
 
-    window.applyFiltersAndDisplay = function() {
-        const filterValue = document.getElementById('branchFilter').value;
-        let filteredRecords = window.currentRecords;
-
-        if (filterValue !== 'all') {
-            filteredRecords = window.currentRecords.filter(record => record.branchName === filterValue);
+    function coerceRecordDate(value) {
+      if (!value) return null;
+      if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value;
+      }
+      if (typeof value === 'object') {
+        if (typeof value.toDate === 'function') {
+          const date = value.toDate();
+          return Number.isNaN(date.getTime()) ? null : date;
         }
-        
-        displayRecords(filteredRecords);
+        if (typeof value.seconds === 'number') {
+          const date = new Date(value.seconds * 1000);
+          return Number.isNaN(date.getTime()) ? null : date;
+        }
+      }
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
     }
 
-    function displayRecords(records) {
+    function getRecordDateIso(record) {
+      const date = coerceRecordDate(record?.date);
+      if (!date) return '';
+      return date.toISOString().slice(0, 10);
+    }
+
+    function getRecordDateDisplay(record) {
+      const date = coerceRecordDate(record?.date);
+      if (!date) return '-';
+      try {
+        return date.toLocaleDateString('es-CL', { timeZone: 'UTC' });
+      } catch (error) {
+        console.warn('No se pudo formatear la fecha con la configuración regional. Se utilizará ISO.', error);
+        return date.toISOString().slice(0, 10);
+      }
+    }
+
+    function getRecordMinSurco(record) {
+      return (record?.tires || []).reduce((min, tire) => {
+        const values = [tire.surco1, tire.surco2, tire.surco3]
+          .map(value => parseFloat(value))
+          .filter(value => Number.isFinite(value));
+        if (!values.length) return min;
+        const localMin = Math.min(...values);
+        return Math.min(min, localMin);
+      }, Infinity);
+    }
+
+    function getRecordMileage(record) {
+      const raw = record?.mileage;
+      if (typeof raw === 'number') {
+        return Number.isFinite(raw) ? raw : null;
+      }
+      if (typeof raw === 'string') {
+        const cleaned = raw.replace(/[^\d]/g, '');
+        if (!cleaned) return null;
+        const parsed = parseInt(cleaned, 10);
+        return Number.isNaN(parsed) ? null : parsed;
+      }
+      return null;
+    }
+
+    function collectHistoryFilters() {
+      const branchFilter = document.getElementById('branchFilter');
+      const branchColumnFilter = document.getElementById('branchColumnFilter');
+      const orderFilter = document.getElementById('orderFilter');
+      const vehicleFilter = document.getElementById('vehicleFilter');
+      const kmFilter = document.getElementById('kmFilter');
+      const dateFilter = document.getElementById('dateFilter');
+      const surcoFilter = document.getElementById('surcoFilter');
+      const kpmmFilter = document.getElementById('kpmmFilter');
+
+      return {
+        branch: branchFilter ? branchFilter.value : 'all',
+        branchColumn: branchColumnFilter ? branchColumnFilter.value : '',
+        order: orderFilter ? orderFilter.value.trim().toLowerCase() : '',
+        vehicle: vehicleFilter ? vehicleFilter.value.trim().toLowerCase() : '',
+        km: kmFilter ? kmFilter.value.trim() : '',
+        date: dateFilter ? dateFilter.value : '',
+        surco: surcoFilter ? surcoFilter.value.trim() : '',
+        kpmm: kpmmFilter ? kpmmFilter.value.trim() : ''
+      };
+    }
+
+    function filterRecordsByValues(records, filters) {
+      const normalizedBranch = (filters.branch || '').toLowerCase();
+      const normalizedBranchColumn = (filters.branchColumn || '').toLowerCase();
+      const normalizedKmDigits = filters.km.replace(/[^0-9]/g, '');
+      const normalizedKmText = filters.km.toLowerCase();
+      const normalizedSurco = filters.surco.replace(',', '.').trim();
+      const normalizedKpmm = filters.kpmm.replace(',', '.').trim();
+
+      return records.filter(record => {
+        const orderStr = `${record.orderNumber ?? ''}`.toLowerCase();
+        if (filters.order && !orderStr.includes(filters.order)) {
+          return false;
+        }
+
+        const branchName = (record.branchName || '').toLowerCase();
+        if (filters.branch && filters.branch !== 'all' && branchName !== normalizedBranch) {
+          return false;
+        }
+
+        if (filters.branchColumn && !branchName.includes(normalizedBranchColumn)) {
+          return false;
+        }
+
+        const vehicleStr = (record.vehicleType || '').toLowerCase();
+        if (filters.vehicle && !vehicleStr.includes(filters.vehicle)) {
+          return false;
+        }
+
+        if (filters.km) {
+          const mileage = getRecordMileage(record);
+          if (normalizedKmDigits) {
+            const mileageDigits = mileage !== null ? mileage.toString() : '';
+            if (!mileageDigits.includes(normalizedKmDigits)) {
+              return false;
+            }
+          } else {
+            const rawMileage = (record.mileage ?? '').toString().toLowerCase();
+            if (!rawMileage.includes(normalizedKmText)) {
+              return false;
+            }
+          }
+        }
+
+        const recordDateIso = getRecordDateIso(record);
+        if (filters.date && recordDateIso !== filters.date) {
+          return false;
+        }
+
+        if (filters.surco) {
+          const minSurco = getRecordMinSurco(record);
+          const surcoText = Number.isFinite(minSurco) ? minSurco.toFixed(1) : '';
+          if (!surcoText.includes(normalizedSurco)) {
+            return false;
+          }
+        }
+
+        if (filters.kpmm) {
+          const kpmm = typeof record.kpmm === 'number' && Number.isFinite(record.kpmm) ? record.kpmm.toString() : '';
+          if (!kpmm.includes(normalizedKpmm)) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+    }
+
+    function getFilteredDataForHistory() {
+      const { recordsWithKpi, categoryAverages } = calculateKpi(window.currentRecords);
+      const filters = collectHistoryFilters();
+      const filteredRecords = filterRecordsByValues(recordsWithKpi, filters);
+      return { filteredRecords, categoryAverages };
+    }
+
+    window.applyFiltersAndDisplay = function() {
+      const { filteredRecords, categoryAverages } = getFilteredDataForHistory();
+      displayRecords(filteredRecords, categoryAverages);
+    }
+
+    function displayRecords(records, categoryAverages) {
       const container = document.getElementById('recordsTableBody');
       if (!container) return;
       if (!records.length) {
-        container.innerHTML = '<tr><td colspan="7" class="text-center py-8 text-gray-500">No hay registros para este filtro.</td></tr>';
+        container.innerHTML = '<tr><td colspan="8" class="text-center py-8 text-gray-500">No hay registros para este filtro.</td></tr>';
         return;
       }
       container.innerHTML = records.map(record => {
-        const dateStr = record.date ? new Date(record.date).toLocaleDateString('es-CL', {timeZone: 'UTC'}) : '-';
-        const minSurco = (record.tires || []).reduce((min, t) => Math.min(min, t.surco1, t.surco2, t.surco3), 99);
-        const criticalClass = minSurco < 3.0 ? 'bg-red-100 text-red-800 font-bold' : (minSurco < 5.0 ? 'bg-yellow-100 text-yellow-800' : 'text-gray-700');
+        const dateStr = getRecordDateDisplay(record);
+        const minSurco = getRecordMinSurco(record);
+        const hasSurcoData = Number.isFinite(minSurco);
+        let criticalClass = 'text-gray-500';
+        if (hasSurcoData) {
+          if (minSurco < 3.0) {
+            criticalClass = 'bg-red-100 text-red-800 font-bold';
+          } else if (minSurco < 5.0) {
+            criticalClass = 'bg-yellow-100 text-yellow-800';
+          } else {
+            criticalClass = 'text-gray-700';
+          }
+        }
+
+        const mileage = getRecordMileage(record);
+        const mileageDisplay = mileage !== null ? `${mileage.toLocaleString('es-CL')} km` : '-';
+
+        const kpmm = typeof record.kpmm === 'number' && Number.isFinite(record.kpmm) ? record.kpmm : null;
+        let kpmmCell = `<td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500" title="Se necesitan al menos dos registros para calcular el rendimiento">N/A</td>`;
+
+        if (kpmm !== null && categoryAverages) {
+          const avg = categoryAverages[record.vehicleType];
+          let colorClass = 'bg-gray-100';
+          if (typeof avg === 'number' && Number.isFinite(avg)) {
+            if (kpmm > avg * 1.15) {
+              colorClass = 'bg-green-100 text-green-800';
+            } else if (kpmm < avg * 0.85) {
+              colorClass = 'bg-red-100 text-red-800';
+            } else {
+              colorClass = 'bg-yellow-100 text-yellow-800';
+            }
+          }
+          kpmmCell = `<td class="px-4 py-3 whitespace-nowrap text-sm font-semibold ${colorClass}">${kpmm.toLocaleString('es-CL')}</td>`;
+        }
+
         return `
           <tr class="border-b hover:bg-gray-50 transition">
             <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900">${record.orderNumber}</td>
             <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600 font-semibold">${record.branchName || 'N/A'}</td>
             <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">${record.vehicleType}</td>
-            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">${(record.mileage || 0).toLocaleString('es-CL')} km</td>
+            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">${mileageDisplay}</td>
             <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">${dateStr}</td>
-            <td class="px-4 py-3 whitespace-nowrap text-sm ${criticalClass}">${isFinite(minSurco) ? minSurco.toFixed(1) : '-'} mm</td>
+            <td class="px-4 py-3 whitespace-nowrap text-sm ${criticalClass}">${hasSurcoData ? `${minSurco.toFixed(1)} mm` : '-'}</td>
+            ${kpmmCell}
             <td class="px-4 py-3 whitespace-nowrap text-right text-sm font-medium">
               <div class="flex items-center justify-end gap-2">
                 <button onclick="window.generatePdf('${record.id}')" class="text-red-600 hover:text-red-800 p-2 rounded-lg transition hover:bg-red-100" title="Generar PDF">
@@ -846,57 +1887,222 @@
       return detail;
     }
 
-    window.exportToCsv = function() {
-      if (!window.currentRecords.length) return displayAppMessage('No hay datos para exportar', 'error');
-      
-      const filterValue = document.getElementById('branchFilter').value;
-      let recordsToExport = window.currentRecords;
+    function exportFilteredData(format) {
+      const { filteredRecords } = getFilteredDataForHistory();
 
-      if (filterValue !== 'all') {
-          recordsToExport = window.currentRecords.filter(record => record.branchName === filterValue);
+      if (!filteredRecords.length) {
+        displayAppMessage('No hay datos para exportar con los filtros aplicados.', 'error');
+        return;
       }
-      
-      let csvContent = "data:text/csv;charset=utf-8,";
-      const superset = Array.from(new Set(Object.values(TIRES_STRUCTURE).flat()));
-      const headers = [
-        "Orden", "Sucursal", "Kilometraje", "Fecha", "Tipo Vehículo", "Marca General", "Medida", "Comentarios", "ID Técnico",
-        ...superset.flatMap(pos => [`Modelo_${pos}`, `Surco1_${pos}`, `Surco2_${pos}`, `Surco3_${pos}`, `FotoURL_${pos}`])
-      ];
-      csvContent += headers.join(";") + "\r\n";
 
-      recordsToExport.forEach(record => {
-        const tireMap = (record.tires || []).reduce((acc, t) => ({ ...acc, [t.position]: t }), {});
-        const row = [
-          record.orderNumber, record.branchName || 'N/A', record.mileage, record.date, record.vehicleType,
-          record.generalMakeModel, record.tireSize, `"${(record.generalComments || '').replace(/"/g, '""')}"`, record.technicianId,
-          ...superset.flatMap(pos => {
-            const t = tireMap[pos];
-            return [t ? t.makeModel : '', t ? t.surco1 : '', t ? t.surco2 : '', t ? t.surco3 : '', t && t.photoURL !== 'N/A' ? t.photoURL : ''];
-          })
+      switch (format) {
+        case 'pdf':
+          exportFilteredToPdf(filteredRecords);
+          break;
+        case 'excel':
+          exportFilteredToExcel(filteredRecords);
+          break;
+        case 'csv':
+          exportFilteredToCsv(filteredRecords);
+          break;
+        default:
+          console.warn('Formato de exportación no soportado:', format);
+      }
+    }
+
+    function exportFilteredToPdf(records) {
+      try {
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF();
+        const generatedAt = new Date();
+        doc.setFontSize(14);
+        doc.setFont('helvetica', 'bold');
+        doc.text('Historial de Registros', 14, 16);
+        doc.setFontSize(10);
+        doc.setFont('helvetica', 'normal');
+        doc.text(`Generado: ${generatedAt.toLocaleDateString('es-CL')}`, 14, 22);
+
+        const tableRows = records.map(record => {
+          const mileage = getRecordMileage(record);
+          const minSurco = getRecordMinSurco(record);
+          const kpmm = typeof record.kpmm === 'number' && Number.isFinite(record.kpmm) ? record.kpmm : null;
+
+          return [
+            record.orderNumber || '',
+            record.branchName || 'N/A',
+            record.vehicleType || 'N/A',
+            mileage !== null ? mileage.toLocaleString('es-CL') : '-',
+            getRecordDateDisplay(record),
+            Number.isFinite(minSurco) ? minSurco.toFixed(1) : '-',
+            kpmm !== null ? kpmm.toLocaleString('es-CL') : 'N/A'
+          ];
+        });
+
+        doc.autoTable({
+          startY: 28,
+          head: [['Orden', 'Sucursal', 'Vehículo', 'KM', 'Fecha', 'Surco Mín. (mm)', 'Rendimiento (km/mm)']],
+          body: tableRows,
+          styles: { fontSize: 8 },
+          headStyles: { fillColor: [5, 150, 105], textColor: 255 },
+          alternateRowStyles: { fillColor: [245, 245, 245] },
+          margin: { left: 14, right: 14 }
+        });
+
+        doc.save(`historial_neumaticos_${generatedAt.toISOString().slice(0, 10)}.pdf`);
+        displayAppMessage('Exportación a PDF completada.', 'success');
+      } catch (error) {
+        console.error('Error al exportar a PDF:', error);
+        displayAppMessage('No se pudo exportar a PDF.', 'error');
+      }
+    }
+
+    function exportFilteredToExcel(records) {
+      try {
+        const rows = records.map(record => {
+          const mileage = getRecordMileage(record);
+          const minSurco = getRecordMinSurco(record);
+          const kpmm = typeof record.kpmm === 'number' && Number.isFinite(record.kpmm) ? Number(record.kpmm.toFixed(2)) : '';
+
+          return {
+            'Orden': record.orderNumber || '',
+            'Sucursal': record.branchName || 'N/A',
+            'Vehículo': record.vehicleType || 'N/A',
+            'KM': mileage !== null ? mileage : '',
+            'Fecha': getRecordDateIso(record),
+            'Surco Mín (mm)': Number.isFinite(minSurco) ? Number(minSurco.toFixed(1)) : '',
+            'Rendimiento (km/mm)': kpmm
+          };
+        });
+
+        const worksheet = XLSX.utils.json_to_sheet(rows);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, 'Historial');
+        XLSX.writeFile(workbook, `historial_neumaticos_${new Date().toISOString().slice(0, 10)}.xlsx`);
+        displayAppMessage('Exportación a Excel completada.', 'success');
+      } catch (error) {
+        console.error('Error al exportar a Excel:', error);
+        displayAppMessage('No se pudo exportar a Excel.', 'error');
+      }
+    }
+
+    function exportFilteredToCsv(records) {
+      try {
+        let csvContent = 'data:text/csv;charset=utf-8,';
+        const superset = Array.from(new Set(Object.values(TIRES_STRUCTURE).flat()));
+        const headers = [
+          'Orden', 'Sucursal', 'Kilometraje', 'Fecha', 'Tipo Vehículo', 'Marca General', 'Medida', 'Comentarios', 'ID Técnico', 'Rendimiento (km/mm)',
+          ...superset.flatMap(pos => [`Modelo_${pos}`, `Surco1_${pos}`, `Surco2_${pos}`, `Surco3_${pos}`, `FotoURL_${pos}`])
         ];
-        csvContent += row.join(";") + "\r\n";
-      });
+        csvContent += headers.join(';') + '\r\n';
 
-      const encodedUri = encodeURI(csvContent);
-      const link = document.createElement("a");
-      link.setAttribute("href", encodedUri);
-      link.setAttribute("download", `registros_neumaticos_${new Date().toISOString().slice(0, 10)}.csv`);
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      displayAppMessage('Exportación a CSV completada.', 'success');
+        records.forEach(record => {
+          const tireMap = (record.tires || []).reduce((acc, tire) => ({ ...acc, [tire.position]: tire }), {});
+          const mileage = getRecordMileage(record);
+          const minifiedComments = (record.generalComments || '').replace(/"/g, '""');
+          const kpmm = typeof record.kpmm === 'number' && Number.isFinite(record.kpmm) ? record.kpmm : '';
+
+          const row = [
+            record.orderNumber || '',
+            record.branchName || 'N/A',
+            mileage !== null ? mileage : '',
+            getRecordDateIso(record),
+            record.vehicleType || '',
+            record.generalMakeModel || '',
+            record.tireSize || '',
+            `"${minifiedComments}"`,
+            record.technicianId || '',
+            kpmm,
+            ...superset.flatMap(pos => {
+              const tire = tireMap[pos];
+              if (!tire) {
+                return ['', '', '', '', ''];
+              }
+              const surco1 = tire.surco1 ?? '';
+              const surco2 = tire.surco2 ?? '';
+              const surco3 = tire.surco3 ?? '';
+              const photo = tire.photoURL && tire.photoURL !== 'N/A' ? tire.photoURL : '';
+              return [tire.makeModel || '', surco1, surco2, surco3, photo];
+            })
+          ];
+
+          csvContent += row.join(';') + '\r\n';
+        });
+
+        const encodedUri = encodeURI(csvContent);
+        const link = document.createElement('a');
+        link.setAttribute('href', encodedUri);
+        link.setAttribute('download', `registros_neumaticos_${new Date().toISOString().slice(0, 10)}.csv`);
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        displayAppMessage('Exportación a CSV completada.', 'success');
+      } catch (error) {
+        console.error('Error al exportar a CSV:', error);
+        displayAppMessage('No se pudo exportar a CSV.', 'error');
+      }
+    }
+
+    window.exportToCsv = function() {
+      exportFilteredData('csv');
     }
     
     // === INICIO DE LA APP ===
     window.onload = function() {
+      loadCatalogFromStorage();
+      renderCatalogLists();
+      attachOrderNumberHandlers();
+      setOrderInputState('loading');
+      ensureOneDriveAccessToken()
+        .catch((error) => {
+          console.warn('No se pudo iniciar sesión automáticamente en OneDrive:', error);
+          clearOneDriveSession();
+        })
+        .finally(() => {
+          loadFleetDataset();
+        });
+
       initializeAppCore().then(() => {
-        const makeModelSelect = document.getElementById('makeModel');
-        const tireSizeSelect = document.getElementById('tireSize');
         const branchSelect = document.getElementById('branchName');
-        PREDEFINED_MODELS.forEach(m => makeModelSelect.insertAdjacentHTML('beforeend', `<option value="${m}">${m}</option>`));
-        PREDEFINED_SIZES.forEach(s => tireSizeSelect.insertAdjacentHTML('beforeend', `<option value="${s}">${s}</option>`));
-        BRANCHES.forEach(b => branchSelect.insertAdjacentHTML('beforeend', `<option value="${b}">${b}</option>`));
-        
+        if (branchSelect) {
+          branchSelect.innerHTML = '<option value="" disabled selected>Selecciona una sucursal...</option>' + BRANCHES.map(branch => `<option value="${branch}">${branch}</option>`).join('');
+        }
+
+        refreshCatalogSelects();
+
+        const exportMenuButton = document.getElementById('exportMenuButton');
+        const exportMenu = document.getElementById('exportMenu');
+        if (exportMenuButton && exportMenu) {
+          const toggleMenu = (shouldShow) => {
+            if (shouldShow) {
+              exportMenu.classList.remove('hidden');
+              exportMenuButton.setAttribute('aria-expanded', 'true');
+            } else {
+              exportMenu.classList.add('hidden');
+              exportMenuButton.setAttribute('aria-expanded', 'false');
+            }
+          };
+
+          exportMenuButton.addEventListener('click', (event) => {
+            event.stopPropagation();
+            const shouldShow = exportMenu.classList.contains('hidden');
+            toggleMenu(shouldShow);
+          });
+
+          document.addEventListener('click', (event) => {
+            if (!exportMenu.contains(event.target) && !exportMenuButton.contains(event.target) && !exportMenu.classList.contains('hidden')) {
+              toggleMenu(false);
+            }
+          });
+
+          exportMenu.querySelectorAll('button[data-export]').forEach(button => {
+            button.addEventListener('click', (event) => {
+              event.stopPropagation();
+              toggleMenu(false);
+              exportFilteredData(button.dataset.export);
+            });
+          });
+        }
+
         window.switchTab('guide');
       });
     }
@@ -907,7 +2113,7 @@
   <div id="app-container" class="flex flex-col">
     <!-- Encabezado Fijo -->
     <header class="bg-white shadow-md sticky top-0 z-10">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+      <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
         <div class="flex justify-between items-center">
           <h1 class="text-2xl font-bold text-gray-800">
             <span class="text-primary">Flota</span> TRACK
@@ -920,18 +2126,20 @@
       </div>
       <!-- Navegación por Pestañas -->
       <nav class="border-t border-gray-200">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
           <div class="flex space-x-4 sm:space-x-8 -mb-px">
             <button id="tab-button-guide" onclick="switchTab('guide')" type="button" class="tab-button">Guía Rápida</button>
             <button id="tab-button-register" onclick="switchTab('register')" type="button" class="tab-button">Registrar</button>
             <button id="tab-button-records" onclick="switchTab('records')" type="button" class="tab-button">Historial</button>
+            <button id="tab-button-admin" onclick="switchTab('admin')" type="button" class="tab-button hidden" data-creator-tab>Catálogo</button>
+            <!-- Para habilitar el acceso privado, elimina la clase "hidden" del botón Catálogo desde las herramientas del navegador. -->
           </div>
         </div>
       </nav>
     </header>
 
     <!-- Contenido Principal -->
-    <main class="flex-grow max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
+    <main class="flex-grow max-w-screen-xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
       <!-- Mensajes Globales de la App -->
       <div id="appMessage" class="hidden opacity-0 max-h-0 transition-all duration-300"></div>
 
@@ -963,8 +2171,14 @@
                 <select id="branchName" name="branchName" class="form-control" required><option value="" disabled selected>Selecciona una sucursal...</option></select>
               </div>
               <div>
-                <label for="orderNumber" class="block text-sm font-medium text-gray-700 mb-1">Número de Orden</label>
-                <input type="number" id="orderNumber" name="orderNumber" class="form-control" placeholder="Ej: 12345" required />
+                <label for="orderNumber" class="block text-sm font-medium text-gray-700 mb-1">Número de Orden (Vehículo)</label>
+                <input type="text" id="orderNumber" name="orderNumber" class="form-control" placeholder="Cargando catálogo..." inputmode="numeric" autocomplete="off" list="orderNumberOptions" required />
+                <datalist id="orderNumberOptions"></datalist>
+                <p id="orderNumberFeedback" class="mt-1 text-xs text-gray-500">Número de orden del vehículo.</p>
+              </div>
+              <div>
+                <label for="vehiclePlate" class="block text-sm font-medium text-gray-700 mb-1">Patente Asociada</label>
+                <input type="text" id="vehiclePlate" name="vehiclePlate" class="form-control readonly-input" placeholder="Se completará automáticamente" readonly tabindex="-1" />
               </div>
               <div>
                 <label for="mileage" class="block text-sm font-medium text-gray-700 mb-1">Kilometraje</label>
@@ -1017,6 +2231,37 @@
             </button>
           </div>
         </form>
+      </div>
+
+      <div id="tab-content-admin" class="hidden">
+        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+          <h2 class="text-xl font-bold text-gray-800 mb-2">Catálogo privado de neumáticos</h2>
+          <p class="text-sm text-gray-600">Esta sección está oculta para el resto del equipo. Utilízala para registrar nuevas marcas/modelos y medidas que luego aparecerán en el formulario principal.</p>
+          <div id="adminFeedback" class="mt-4 text-sm text-gray-500"></div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+            <form id="catalogModelForm" onsubmit="handleAdminAddModel(event)" class="space-y-3">
+              <h3 class="text-lg font-semibold text-gray-700">Registrar marca/modelo</h3>
+              <p class="text-xs text-gray-500">Agrega combinaciones para reutilizarlas en la medición general o por neumático.</p>
+              <input type="text" id="newModel" class="form-control" placeholder="Ej: Continental Conti Coach HA3" required />
+              <button type="submit" class="px-4 py-2 bg-primary text-white text-sm font-semibold rounded-lg hover:bg-secondary transition">Guardar modelo</button>
+            </form>
+            <form id="catalogSizeForm" onsubmit="handleAdminAddSize(event)" class="space-y-3">
+              <h3 class="text-lg font-semibold text-gray-700">Registrar medida</h3>
+              <p class="text-xs text-gray-500">Agrega nuevas medidas (usa formato 295/80R22.5).</p>
+              <input type="text" id="newSize" class="form-control" placeholder="Ej: 275/70R22.5" required />
+              <button type="submit" class="px-4 py-2 bg-secondary text-white text-sm font-semibold rounded-lg hover:bg-primary transition">Guardar medida</button>
+            </form>
+          </div>
+          <div class="mt-8">
+            <h3 class="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">Modelos personalizados</h3>
+            <div id="customModelList" class="flex flex-wrap gap-2"></div>
+          </div>
+          <div class="mt-6">
+            <h3 class="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">Medidas personalizadas</h3>
+            <div id="customSizeList" class="flex flex-wrap gap-2"></div>
+          </div>
+          <p class="mt-6 text-xs text-gray-400">Los datos se almacenan localmente en este navegador. Exporta la lista si deseas respaldarla.</p>
+        </div>
       </div>
 
       <div id="tab-content-records" class="hidden">
@@ -1034,9 +2279,28 @@
                 <button onclick="generateGeneralReport()" class="px-4 py-2 bg-blue-600 text-white font-semibold text-sm rounded-lg shadow-sm hover:bg-blue-700 transition">
                     Informe General
                 </button>
-                <button onclick="exportToCsv()" class="px-4 py-2 bg-secondary text-white font-semibold text-sm rounded-lg shadow-sm hover:bg-primary transition">
-                    Exportar a CSV
-                </button>
+                <div class="relative" id="exportMenuWrapper">
+                    <button id="exportMenuButton" type="button" class="px-4 py-2 bg-secondary text-white font-semibold text-sm rounded-lg shadow-sm hover:bg-primary transition flex items-center gap-2" aria-haspopup="true" aria-expanded="false">
+                        Exportar
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </button>
+                    <div id="exportMenu" class="absolute right-0 mt-2 w-44 bg-white border border-gray-200 rounded-lg shadow-lg py-1 hidden z-10">
+                        <button type="button" data-export="pdf" class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+                            <span class="inline-flex w-2 h-2 rounded-full bg-red-500"></span>
+                            PDF
+                        </button>
+                        <button type="button" data-export="excel" class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+                            <span class="inline-flex w-2 h-2 rounded-full bg-green-500"></span>
+                            Excel
+                        </button>
+                        <button type="button" data-export="csv" class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+                            <span class="inline-flex w-2 h-2 rounded-full bg-amber-500"></span>
+                            CSV
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
         <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-x-auto">
@@ -1049,931 +2313,34 @@
                         <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">KM</th>
                         <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Fecha</th>
                         <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Surco Mín.</th>
+                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Rendimiento (km/mm)</th>
                         <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider text-right">Acciones</th>
                     </tr>
-                </thead>
-                <tbody id="recordsTableBody">
-                    <!-- Filas se insertarán dinámicamente -->
-                </tbody>
-            </table>
-        </div>
-      </div>
-
-    </main>
-  </div>
-</body>
-</html>
-
-
-        extend: {
-          colors: {
-            primary: "#059669",
-            secondary: "#10b981",
-            accent: "#fbbf24",
-            background: "#f9fafb",
-          },
-          fontFamily: {
-            sans: ["Inter", "sans-serif"]
-          },
-        },
-      },
-    };
-  </script>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <style>
-    html, body { height: 100%; margin: 0; padding: 0; font-family: 'Inter', sans-serif; }
-    #app-container { min-height: 100vh; }
-    .tab-button { transition: all 0.2s; padding: 1rem 0.5rem; border-bottom: 4px solid transparent; }
-    .tab-button.active { border-bottom-color: #059669; font-weight: 600; color: #059669; }
-    .form-control { border-radius: 0.5rem; border: 1px solid #d1d5db; padding: 0.5rem 0.75rem; width: 100%; transition: all 0.15s; }
-    .form-control:focus { border-color: #059669; box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.2); outline: none; }
-  </style>
-
-  <!-- Librerías para generar PDF -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
-
-  <script type="module">
-    import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
-    import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-    import { getFirestore, addDoc, onSnapshot, collection, query, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
-    import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
-
-    // === CONFIGURACIÓN ===
-    const GEMINI_MODEL = "gemini-2.5-flash-preview-05-20";
-    const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
-    const apiKey = typeof __gemini_key !== 'undefined' ? __gemini_key : "";
-    const BRANCHES = ["Copiapó", "Vallenar", "Santiago", "Viña del Mar", "Casa Matriz"];
-    const TIRES_STRUCTURE = {
-      'Bus': ['P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'Repuesto'],
-      'Taxibus': ['P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'Repuesto'],
-      'Minibús': ['P1', 'P2', 'P3', 'P4', 'Repuesto'],
-      'Minibús DR (Doble Rodado)': ['P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'Repuesto'],
-      'Camioneta': ['P1', 'P2', 'P3', 'P4', 'Repuesto'],
-    };
-    const PREDEFINED_MODELS = [
-      'Michelin X Multiway 3D XZE', 'Pirelli FH:01 Energy', 'Bridgestone R260', 'Dunlop SP338', 'Goodyear KMAX S', 'Continental HT3', 'Hankook SmartFlex AH31', 'Westlake CB867', 'Sailun S701'
-    ];
-    const PREDEFINED_SIZES = ['225/75R16', '245/70R19.5', '275/80R22.5', '295/80R22.5', '315/80R22.5', '11R22.5', '12R22.5', '10.00R20'];
-    const longevityTips = [
-      "Mantén la <strong>presión correcta</strong> semanalmente. La subinflación es el principal asesino de neumáticos.",
-      "Realiza la <strong>rotación</strong> cada 10–12 mil km para asegurar un desgaste uniforme.",
-      "Alinea si notas desgaste irregular o tras golpes fuertes.",
-      "Balancea al montar o tras reparaciones para evitar vibraciones.",
-      "Inspecciona cortes, protuberancias y objetos incrustados.",
-      "Conduce suave: evita frenazos y acelerones.",
-      "Revisa suspensión/amortiguadores: influyen en el desgaste.",
-      "Limpia neumáticos y llantas con regularidad.",
-    ];
-
-    // === ESTADO GLOBAL DE LA APLICACIÓN ===
-    let app = null, db = null, auth = null, storage = null;
-    let currentUserId = null;
-    let authReady = false;
-    let unsubscribeRecords = null;
-    window.currentRecords = [];
-    window.pendingReviewData = null;
-
-    // --- TUS CREDENCIALES DE FIREBASE ---
-    const firebaseConfig = {
-        apiKey: "AIzaSyBtc4KcGwNr4y79YeI4EdUX9mBSfindhH0",
-        authDomain: "neumaticos-fv.firebaseapp.com",
-        projectId: "neumaticos-fv",
-        storageBucket: "neumaticos-fv.appspot.com",
-        messagingSenderId: "50061965881",
-        appId: "1:50061965881:web:31c43abfeabc0c0ed8ebe8",
-        measurementId: "G-LZVB5CT01W"  
-    };
-
-    const appId = 'flota-track-app';
-
-    // === INICIALIZACIÓN (CÓDIGO FUNCIONAL) ===
-    async function initializeAppCore() {
-      setUiState('loading');
-      
-      try {
-        app = initializeApp(firebaseConfig);
-        db = getFirestore(app);
-        storage = getStorage(app);
-        auth = getAuth(app);
-
-        onAuthStateChanged(auth, user => {
-          if (user) {
-            currentUserId = user.uid;
-            authReady = true;
-            setUiState('authenticated', `ID: ${currentUserId.substring(0, 8)}...`);
-            if (window.currentRecords.length === 0) {
-              loadRecords();
-            }
-          } else {
-            currentUserId = null;
-            authReady = false;
-            setUiState('unauthenticated');
-          }
-        });
-
-        await attemptInitialSignIn();
-
-      } catch (e) {
-        setUiState('error', 'Error crítico al iniciar Firebase.');
-        console.error("Error crítico de inicialización de Firebase:", e);
-      }
-    }
-
-    async function attemptInitialSignIn() {
-      try {
-        await signInAnonymously(auth);
-      } catch (error) {
-        console.error("Fallo el intento de inicio de sesión:", error.code, error.message);
-        let friendlyMessage = "Error de autenticación desconocido.";
-        switch (error.code) {
-          case 'auth/network-request-failed':
-            friendlyMessage = "Falla de red. Revisa tu conexión.";
-            break;
-          case 'auth/operation-not-allowed':
-            friendlyMessage = "Inicio de sesión anónimo no habilitado.";
-            break;
-        }
-        setUiState('error', friendlyMessage);
-      }
-    }
-    
-    // === GESTIÓN DE DATOS (FIRESTORE) ===
-    function loadRecords() {
-      if (!db || !authReady) return;
-      if (typeof unsubscribeRecords === 'function') {
-        unsubscribeRecords();
-      }
-      const recordsRef = collection(db, `/artifacts/${appId}/public/data/tire_records`);
-      const q = query(recordsRef);
-
-      unsubscribeRecords = onSnapshot(q, (snapshot) => {
-        const records = [];
-        snapshot.forEach((doc) => records.push({ id: doc.id, ...doc.data() }));
-        window.currentRecords = records.sort((a, b) => (b.orderNumber || 0) - (a.orderNumber || 0));
-        displayRecords(window.currentRecords);
-      }, (err) => console.error("Error en onSnapshot:", err));
-    }
-
-    async function uploadPhoto(file, position) {
-      if (!storage || !currentUserId) throw new Error("Storage o usuario no disponibles");
-      const ext = (file.name.split('.').pop() || 'jpg').toLowerCase();
-      const fileName = `${currentUserId}_${position}_${Date.now()}.${ext}`;
-      const storageRef = ref(storage, `tire_photos/${currentUserId}/${fileName}`);
-      await uploadBytes(storageRef, file);
-      return getDownloadURL(storageRef);
-    }
-    
-    // === LÓGICA DE LA APLICACIÓN ===
-    window.handleSave = async function() {
-      if (!authReady || !window.pendingReviewData) {
-        return displayAppMessage(authReady ? 'Evalúa antes de guardar' : 'Error de autenticación.', 'error');
-      }
-
-      const data = window.pendingReviewData;
-      const saveBtn = document.getElementById('saveButton');
-      saveBtn.disabled = true;
-      saveBtn.innerHTML = getLoaderSvg('Guardando...');
-
-      try {
-        const uploadedPhotos = await Promise.all((data.photoFiles || []).map(async item => ({
-          position: item.position,
-          url: await uploadPhoto(item.file, item.position)
-        })));
-        
-        data.tires = data.tires.map(tire => {
-          const foundPhoto = uploadedPhotos.find(p => p.position === tire.position);
-          return { ...tire, photoURL: foundPhoto ? foundPhoto.url : 'N/A' };
-        });
-
-        const { photoFiles, ...finalRecord } = { ...data, timestamp: serverTimestamp() };
-        const recordsRef = collection(db, `/artifacts/${appId}/public/data/tire_records`);
-        await addDoc(recordsRef, finalRecord);
-
-        displayAppMessage('✅ Registro guardado con éxito', 'success');
-        resetRegistrationForm();
-        window.switchTab('records');
-
-      } catch (e) {
-        console.error('Error al guardar:', e);
-        displayAppMessage(`❌ Error al guardar: ${e.message}`, 'error');
-      } finally {
-        saveBtn.disabled = true;
-        saveBtn.innerHTML = 'Guardar Registro';
-      }
-    }
-    
-    // === LÓGICA DE IA (GEMINI) ===
-    window.analyzeRecord = async function(recordId) {
-      if (!authReady) return displayAppMessage('Error: Base de datos no inicializada.', 'error');
-      
-      const record = window.currentRecords.find(r => r.id === recordId);
-      if (!record) return displayAppMessage('Registro no encontrado', 'error');
-      
-      displayAppMessage(`Iniciando análisis para Orden N° ${record.orderNumber}...`, 'info');
-
-      const recordDetails = formatRecordForPrompt(record);
-      const systemPrompt = "Actúa como ingeniero de mantenimiento de flotas y experto en neumáticos. Analiza el informe de surcos. Indica neumáticos críticos (<3mm) y sugiere un plan de acción conciso y priorizado (rotación, reemplazo, alineación, presión). Usa fuentes web si es útil y lista las citas.";
-      const userQuery = `Análisis de la Orden N° ${record.orderNumber} con ${record.mileage} km:\n\n${recordDetails}`;
-      const payload = {
-        contents: [{ parts: [{ text: userQuery }] }],
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        tools: [{ "google_search": {} }]
-      };
-
-      try {
-        const res = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
-        if (!res.ok) throw new Error(`Gemini API request failed with status ${res.status}`);
-
-        const result = await res.json();
-        const candidate = result?.candidates?.[0];
-        const text = candidate?.content?.parts?.[0]?.text || 'No se pudo generar un análisis.';
-        const sources = (candidate?.groundingMetadata?.groundingAttributions || []).map(a => ({ uri: a?.web?.uri, title: a?.web?.title })).filter(s => s.uri && s.title);
-        
-        displayAppMessage(`✅ Análisis de Orden N° ${record.orderNumber} generado.`, 'success');
-        console.log(`--- Análisis Gemini Orden N° ${record.orderNumber} ---`);
-        console.log(text);
-        if (sources.length) {
-          console.log("\nFuentes:");
-          sources.forEach(s => console.log(`- ${s.title}: ${s.uri}`));
-        }
-        console.log("-----------------------------------------------------");
-
-      } catch (e) {
-        console.error("Error en el análisis con Gemini:", e);
-        displayAppMessage('Error al conectar con la IA.', 'error');
-      }
-    }
-
-    // === GENERACIÓN DE PDF ===
-    const logoBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAFeCAYAAABukM3AAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAE9YSURBVHhe7d15fFTV9f/xT5MkARIssEk2WCCybYVdtgq27f4vuIKKBYQLgoJll1244CIIKC44KuiuKCAqKgoKuOAsCKIiKAgKuy2AbLdlQRDZJrBNsEmYJJn+/midmUxyM3fnzklO8v28Pp/JJTfnzM15SXbu3DlzT/f09MTm5ma/u19+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn5+fn-girdim';
-
-    function generateRecommendations(record) {
-        const recommendations = new Set();
-        const replacementThreshold = 3.0;
-        const monitorThreshold = 5.0;
-        const irregularWearThreshold = 2.0;
-
-        record.tires.forEach(tire => {
-            const surcos = [tire.surco1, tire.surco2, tire.surco3];
-            const minSurco = Math.min(...surcos);
-            const maxSurco = Math.max(...surcos);
-            const diff = maxSurco - minSurco;
-
-            if (minSurco < replacementThreshold) {
-                recommendations.add(`- Reemplazo Urgente: El neumático en la posición ${tire.position} (${minSurco.toFixed(1)} mm) está por debajo del límite de seguridad.`);
-            } else if (minSurco < monitorThreshold) {
-                recommendations.add(`- Monitorear: El neumático en la posición ${tire.position} (${minSurco.toFixed(1)} mm) se acerca al final de su vida útil.`);
-            }
-
-            if (diff >= irregularWearThreshold) {
-                recommendations.add(`- Revisar Alineación y Balanceo: Se detectó desgaste irregular en la posición ${tire.position} (diferencia de ${diff.toFixed(1)} mm).`);
-            }
-        });
-
-        if (record.tires.length > 2) {
-             recommendations.add('- Planificar Rotación: Considere rotar los neumáticos para promover un desgaste uniforme en el próximo mantenimiento.');
-        }
-
-        recommendations.add('- Verificación de Presión: Es crucial revisar y ajustar la presión de todos los neumáticos semanalmente según las especificaciones del fabricante.');
-
-        if (recommendations.size === 1) { 
-            return ['- Todos los neumáticos se encuentran en buen estado. Continuar con las revisiones periódicas de presión.'];
-        }
-
-        return Array.from(recommendations);
-    }
-
-    window.generatePdf = async function(recordId) {
-        displayAppMessage('Generando PDF, por favor espera...', 'info');
-        
-        try {
-            const record = window.currentRecords.find(r => r.id === recordId);
-            if (!record) throw new Error('Registro no encontrado.');
-
-            const { jsPDF } = window.jspdf;
-            const doc = new jsPDF();
-
-            try {
-                if (logoBase64) {
-                    doc.addImage(logoBase64, 'PNG', 15, 10, 50, 16);
-                }
-            } catch (e) {
-                console.error("Error al añadir el logo al PDF. Se generará sin logo.", e);
-            }
-
-            doc.setFontSize(22);
-            doc.setFont('helvetica', 'bold');
-            doc.text("Registro de Desgaste de Neumáticos", 195, 20, { align: 'right' });
-            doc.setLineWidth(0.5);
-            doc.line(15, 30, 195, 30);
-
-            let yPos = 40;
-            doc.setFontSize(12);
-            doc.setFont('helvetica', 'bold');
-            doc.text("Información General", 15, yPos);
-            yPos += 8;
-            doc.setFont('helvetica', 'normal');
-            doc.text(`N° Orden: ${record.orderNumber}`, 15, yPos);
-            doc.text(`Fecha: ${new Date(record.date).toLocaleDateString('es-CL', {timeZone: 'UTC'})}`, 105, yPos);
-            yPos += 7;
-            doc.text(`Sucursal: ${record.branchName}`, 15, yPos);
-            doc.text(`Kilometraje: ${record.mileage.toLocaleString('es-CL')} km`, 105, yPos);
-            yPos += 7;
-            doc.text(`Tipo de Vehículo: ${record.vehicleType}`, 15, yPos);
-            yPos += 7;
-            doc.text(`Marca/Modelo General: ${record.generalMakeModel}`, 15, yPos);
-            yPos += 7;
-            doc.text(`Medida General: ${record.tireSize}`, 15, yPos);
-            yPos += 7;
-            if(record.generalComments) {
-                const splitComments = doc.splitTextToSize(`Comentarios: ${record.generalComments}`, 180);
-                doc.text(splitComments, 15, yPos);
-                yPos += (splitComments.length * 5);
-            }
-
-            const tireData = record.tires.map(t => [t.position, t.makeModel, t.surco1.toFixed(1), t.surco2.toFixed(1), t.surco3.toFixed(1)]);
-            doc.autoTable({
-                startY: yPos + 5,
-                head: [['Posición', 'Marca/Modelo', 'Surco 1 (mm)', 'Surco 2 (mm)', 'Surco 3 (mm)']],
-                body: tireData,
-                theme: 'grid',
-                headStyles: { fillColor: [5, 150, 105] },
-                didParseCell: function (data) {
-                    if (data.column.index >= 2 && data.column.index <= 4) {
-                        let value = parseFloat(data.cell.raw);
-                        if (!isNaN(value) && value < 3.0) {
-                            data.cell.styles.fillColor = '#FFDDE0';
-                            data.cell.styles.textColor = '#900C3F';
-                            data.cell.styles.fontStyle = 'bold';
-                        }
-                    }
-                }
-            });
-
-            yPos = doc.lastAutoTable.finalY + 10;
-            
-            // Sección de Recomendaciones
-            doc.setFontSize(14);
-            doc.setFont('helvetica', 'bold');
-            doc.text("Recomendaciones", 15, yPos);
-            yPos += 8;
-
-            const recommendations = generateRecommendations(record);
-            doc.setFontSize(10);
-            doc.setFont('helvetica', 'normal');
-            doc.setTextColor(40);
-            recommendations.forEach(rec => {
-                if (yPos > 270) { 
-                    doc.addPage();
-                    yPos = 20;
-                }
-                const splitText = doc.splitTextToSize(rec, 180);
-                doc.text(splitText, 15, yPos);
-                yPos += (splitText.length * 5) + 2; 
-            });
-            doc.setTextColor(0);
-
-
-            const imageTires = record.tires.filter(t => t.photoURL && t.photoURL !== 'N/A');
-            if (imageTires.length > 0) {
-                 if (yPos > 180) { // Check if there's enough space for the title and at least one image
-                    doc.addPage();
-                    yPos = 20;
-                }
-                doc.setFontSize(14);
-                doc.setFont('helvetica', 'bold');
-                doc.text("Fotografías Adjuntas", 15, yPos);
-                yPos += 10;
-                
-                const imagePromises = imageTires.map(async (tire) => {
-                    try {
-                        const response = await fetch(tire.photoURL);
-                        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-                        const blob = await response.blob();
-                        const imageBase64 = await new Promise((resolve, reject) => {
-                            const reader = new FileReader();
-                            reader.onloadend = () => resolve(reader.result);
-                            reader.onerror = reject;
-                            reader.readAsDataURL(blob);
-                        });
-                        return { tire, imageBase64, status: 'fulfilled' };
-                    } catch (e) {
-                        console.error(`No se pudo cargar la imagen para ${tire.position}:`, e);
-                        return { tire, status: 'rejected' };
-                    }
-                });
-
-                const imageResults = await Promise.all(imagePromises);
-
-                for (const result of imageResults) {
-                     if (yPos > 220) { 
-                        doc.addPage();
-                        yPos = 20;
-                    }
-                    doc.setFontSize(10);
-                    doc.setFont('helvetica', 'normal');
-                    if(result.status === 'fulfilled') {
-                        doc.text(`Posición: ${result.tire.position} (${result.tire.makeModel})`, 15, yPos);
-                        doc.addImage(result.imageBase64, 'JPEG', 15, yPos + 3, 80, 60);
-                        yPos += 70;
-                    } else {
-                        doc.text(`- Imagen no disponible para la posición ${result.tire.position}.`, 15, yPos);
-                        yPos += 7;
-                    }
-                }
-            }
-            
-            doc.output('dataurlnewwindow');
-            
-            displayAppMessage('✅ PDF generado con éxito.', 'success');
-
-        } catch (error) {
-            console.error("Error al generar el PDF:", error);
-            displayAppMessage(`Error al generar el PDF: ${error.message}`, 'error');
-        }
-    }
-    
-    // === HELPERS Y UI ===
-    function setUiState(state, message = '') {
-      const errorEl = document.getElementById('firebaseErrorDisplay');
-      const idEl = document.getElementById('userIdDisplay');
-      const formButtons = ['reviewButton', 'saveButton'];
-      
-      errorEl.textContent = '';
-      idEl.textContent = '';
-      let disableButtons = true;
-
-      switch(state) {
-        case 'loading':
-          idEl.textContent = 'Conectando...';
-          break;
-        case 'authenticated':
-          idEl.textContent = message;
-          disableButtons = false;
-          break;
-        case 'unauthenticated':
-          idEl.textContent = 'No autenticado';
-          break;
-        case 'error':
-          errorEl.textContent = message;
-          idEl.textContent = 'Desconectado';
-          break;
-      }
-      
-      formButtons.forEach(id => {
-          const btn = document.getElementById(id);
-          if(btn) btn.disabled = disableButtons;
-      });
-      if(state === 'authenticated' && document.getElementById('vehicleType')?.value) {
-          document.getElementById('reviewButton').disabled = false;
-      }
-    }
-
-    window.switchTab = function(tabName) {
-      ['guide', 'register', 'records'].forEach(tab => {
-        document.getElementById(`tab-button-${tab}`)?.classList.toggle('active', tab === tabName);
-        document.getElementById(`tab-content-${tab}`)?.classList.toggle('hidden', tab !== tabName);
-      });
-      if (tabName === 'guide') updateRandomRecommendation();
-      if (tabName === 'register') resetRegistrationForm();
-    }
-
-    function resetRegistrationForm() {
-      const form = document.getElementById('registrationForm');
-      if (form) form.reset();
-      document.getElementById('tireInputsContainer').innerHTML = '';
-      document.getElementById('reviewFeedback').innerHTML = '';
-      const saveBtn = document.getElementById('saveButton');
-      if (saveBtn) saveBtn.disabled = true;
-      const reviewBtn = document.getElementById('reviewButton');
-      if (reviewBtn) reviewBtn.disabled = true;
-      const dateEl = document.getElementById('date');
-      if (dateEl) dateEl.value = new Date().toISOString().slice(0, 10);
-    }
-
-    window.generateTireInputs = function() {
-      const vehicleType = document.getElementById('vehicleType').value;
-      const container = document.getElementById('tireInputsContainer');
-      container.innerHTML = '';
-      const positions = TIRES_STRUCTURE[vehicleType] || [];
-
-      positions.forEach((position, index) => {
-        const positionDesc = getPositionDescription(position);
-        const block = `
-          <div class="p-4 border border-gray-200 rounded-xl shadow-sm mb-4 bg-white">
-            <h4 class="text-lg font-semibold text-primary mb-2">Neumático - Posición ${index + 1} (${position})</h4>
-            <p class="text-sm text-gray-500 mb-4">${positionDesc}</p>
-            <div class="mb-4">
-              <label class="block text-xs font-medium text-gray-700 mb-1" for="tireMakeModel-${index}">Marca y Modelo (Específico)</label>
-              <select id="tireMakeModel-${index}" name="tireMakeModel_${position}" class="form-control text-sm">
-                <option value="" selected>Usar marca general del formulario</option>
-                ${PREDEFINED_MODELS.map(m => `<option value="${m}">${m}</option>`).join('')}
-              </select>
-            </div>
-            <div class="grid grid-cols-3 gap-2 mb-4">
-              ${[1, 2, 3].map(i => `
-                <div>
-                  <label class="block text-xs font-medium text-gray-700 mb-1" for="surco-${index}-${i}">Surco ${i} (mm)</label>
-                  <input type="number" id="surco-${index}-${i}" name="surco_${position}_${i}" min="0" max="25" step="0.1" class="form-control text-sm" placeholder="Ej: 5.5" required />
-                </div>`).join('')}
-            </div>
-            <div>
-              <label class="block text-xs font-medium text-gray-700 mb-1" for="photo-${index}">Foto (opcional)</label>
-              <input type="file" id="photo-${index}" name="photo_${position}" accept="image/jpeg,image/png" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-secondary/10 file:text-secondary hover:file:bg-secondary/20" />
-            </div>
-          </div>`;
-        container.insertAdjacentHTML('beforeend', block);
-      });
-      document.getElementById('reviewButton').disabled = positions.length === 0 || !authReady;
-    }
-
-    window.handleReview = function(event) {
-        event.preventDefault();
-        const form = document.getElementById('registrationForm');
-        const reviewBtn = document.getElementById('reviewButton');
-        const saveBtn = document.getElementById('saveButton');
-        
-        if (!authReady) {
-            displayReview([{type: 'error', text: 'Base de datos no lista. Espera la autenticación.'}]);
-            return;
-        }
-
-        reviewBtn.disabled = true;
-        reviewBtn.innerHTML = getLoaderSvg("Evaluando...");
-        saveBtn.disabled = true;
-        window.pendingReviewData = null;
-
-        const formData = new FormData(form);
-        const generalData = Object.fromEntries(formData.entries());
-
-        const requiredFields = ['branchName', 'orderNumber', 'mileage', 'date', 'tireSize', 'makeModel'];
-        if (requiredFields.some(field => !generalData[field])) {
-            displayReview([{type: 'error', text: 'Completa todos los campos generales (Sucursal, Orden, KM, Fecha, etc.).'}]);
-            finishReview(reviewBtn);
-            return;
-        }
-
-        const data = {
-            orderNumber: parseInt(generalData.orderNumber),
-            mileage: parseInt(generalData.mileage),
-            date: generalData.date,
-            tireSize: generalData.tireSize,
-            vehicleType: generalData.vehicleType,
-            generalMakeModel: generalData.makeModel,
-            generalComments: generalData.generalComments || '',
-            technicianId: currentUserId,
-            branchName: generalData.branchName,
-            tires: [],
-            photoFiles: []
-        };
-
-        const positions = TIRES_STRUCTURE[data.vehicleType] || [];
-        let dataError = false;
-        let reviewMessages = [];
-
-        positions.forEach(position => {
-            if (dataError) return;
-            const s1 = parseFloat(form[`surco_${position}_1`]?.value);
-            const s2 = parseFloat(form[`surco_${position}_2`]?.value);
-            const s3 = parseFloat(form[`surco_${position}_3`]?.value);
-            const makeModel = form[`tireMakeModel_${position}`]?.value || data.generalMakeModel;
-            const photoFile = form[`photo_${position}`]?.files[0] || null;
-
-            if ([s1, s2, s3].some(v => isNaN(v))) {
-                reviewMessages.push({type: 'error', text: `Error en ${position}: surcos incompletos o inválidos.`});
-                dataError = true; return;
-            }
-
-            const minSurco = Math.min(s1, s2, s3);
-            const maxSurco = Math.max(s1, s2, s3);
-            const diff = maxSurco - minSurco;
-
-            data.tires.push({ position, makeModel, surco1: s1, surco2: s2, surco3: s3 });
-            if (photoFile) data.photoFiles.push({ file: photoFile, position });
-
-            if (minSurco < 3.0) reviewMessages.push({type: 'alert', text: `⚠️ ${position} (${makeModel}) min ${minSurco.toFixed(1)} mm → <strong>REEMPLAZO OBLIGATORIO</strong>.`});
-            else if (minSurco < 5.0) reviewMessages.push({type: 'warning', text: `🟠 ${position} (${makeModel}) min ${minSurco.toFixed(1)} mm → Monitorear, próximo a reemplazo.`});
-            if (diff > 2.0) reviewMessages.push({type: 'alert', text: `🚨 Desgaste irregular en ${position}. Δ ${diff.toFixed(1)} mm → Revisar <strong>alineación y presión</strong>.`});
-        });
-
-        if (dataError) {
-            displayReview(reviewMessages);
-            finishReview(reviewBtn);
-            return;
-        }
-
-        if (reviewMessages.length === 0) {
-            reviewMessages.push({type: 'success', text: '✅ Todos los neumáticos en buen estado. Listo para guardar.'});
-        }
-        
-        window.pendingReviewData = data;
-        saveBtn.disabled = false;
-        displayReview(reviewMessages);
-        finishReview(reviewBtn);
-        displayAppMessage('Revisión completa. Presiona "Guardar Registro".', 'success');
-    }
-
-    function finishReview(btn) {
-      if (authReady) btn.disabled = !document.getElementById('vehicleType')?.value;
-      btn.innerHTML = 'Evaluar Medición';
-    }
-    
-    function displayReview(messages) {
-      const container = document.getElementById('reviewFeedback');
-      const typeClasses = {
-        alert: 'bg-red-100 text-red-800 border-red-400',
-        warning: 'bg-yellow-100 text-yellow-800 border-yellow-400',
-        success: 'bg-green-100 text-green-800 border-green-400 font-bold',
-        error: 'bg-gray-200 text-gray-800 border-red-500 font-bold',
-      };
-      container.innerHTML = messages.map(m => `
-        <div class="p-3 rounded-lg text-sm mb-2 shadow-sm border-l-4 ${typeClasses[m.type] || 'bg-blue-100 text-blue-800 border-blue-400'}">
-          ${m.text}
-        </div>`).join('');
-    }
-
-    function getPositionDescription(pos) {
-      const descriptions = {
-        'P1': 'Eje 1 - Delantera Izquierda (Conductor)', 'P2': 'Eje 1 - Delantera Derecha',
-        'P3': 'Eje 2 - Trasera Izquierda', 'P6': 'Eje 2 - Trasera Derecha',
-        'P4': 'Eje 2 (Interior) - Izquierda (Doble Rodado)', 'P5': 'Eje 2 (Interior) - Derecha (Doble Rodado)',
-        'Repuesto': 'Rueda de Repuesto'
-      };
-      return descriptions[pos] || pos;
-    }
-
-    function getLoaderSvg(label) {
-      return `<svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-white inline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg> ${label}`;
-    }
-
-    function displayAppMessage(message, type = 'info') {
-      const container = document.getElementById('appMessage');
-      const typeClasses = {
-        success: 'bg-green-500 text-white',
-        error: 'bg-red-500 text-white',
-        info: 'bg-blue-500 text-white'
-      };
-      container.className = `p-3 rounded-lg text-sm mb-4 font-medium shadow-md transition-all duration-300 ${typeClasses[type]}`;
-      container.textContent = message;
-      container.classList.remove('opacity-0', 'hidden', 'max-h-0', 'py-0', 'mb-0');
-      container.style.maxHeight = '100px';
-
-      setTimeout(() => {
-        container.classList.add('opacity-0');
-        container.style.maxHeight = '0px';
-        setTimeout(() => container.classList.add('hidden'), 300);
-      }, 5000);
-    }
-
-    function updateRandomRecommendation() {
-      const tip = longevityTips[Math.floor(Math.random() * longevityTips.length)];
-      document.getElementById('randomTip').innerHTML = tip;
-    }
-
-    function displayRecords(records) {
-      const container = document.getElementById('recordsTableBody');
-      if (!container) return;
-      if (!records.length) {
-        container.innerHTML = '<tr><td colspan="7" class="text-center py-8 text-gray-500">No hay registros disponibles.</td></tr>';
-        return;
-      }
-      container.innerHTML = records.map(record => {
-        const dateStr = record.date ? new Date(record.date).toLocaleDateString('es-CL', {timeZone: 'UTC'}) : '-';
-        const minSurco = (record.tires || []).reduce((min, t) => Math.min(min, t.surco1, t.surco2, t.surco3), 99);
-        const criticalClass = minSurco < 3.0 ? 'bg-red-100 text-red-800 font-bold' : (minSurco < 5.0 ? 'bg-yellow-100 text-yellow-800' : 'text-gray-700');
-        return `
-          <tr class="border-b hover:bg-gray-50 transition">
-            <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900">${record.orderNumber}</td>
-            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-600 font-semibold">${record.branchName || 'N/A'}</td>
-            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">${record.vehicleType}</td>
-            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">${(record.mileage || 0).toLocaleString('es-CL')} km</td>
-            <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500">${dateStr}</td>
-            <td class="px-4 py-3 whitespace-nowrap text-sm ${criticalClass}">${isFinite(minSurco) ? minSurco.toFixed(1) : '-'} mm</td>
-            <td class="px-4 py-3 whitespace-nowrap text-right text-sm font-medium">
-              <div class="flex items-center justify-end gap-2">
-                <button onclick="window.generatePdf('${record.id}')" class="text-red-600 hover:text-red-800 p-2 rounded-lg transition hover:bg-red-100" title="Generar PDF">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
-                    <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 1.5L14 6v8.5a.5.5 0 0 1-.5.5H4a.5.5 0 0 1-.5-.5v-12A.5.5 0 0 1 4 1.5h5.5z"/>
-                    <path d="M4.603 12.087a.81.81 0 0 1-.438.448l-.175.082a.558.558 0 0 1-.685-.28.52.52 0 0 1 .035-.634l.116-.117.175-.082a.81.81 0 0 1 .438-.448l.175-.082.685.28a.52.52 0 0 1-.035.634l-.116.117-.175.082zm1.833-1.422a.512.512 0 0 1-.028.682l-.206.206a.512.512 0 0 1-.682.028l-.206-.206a.512.512 0 0 1 .028-.682l.206-.206a.512.512 0 0 1 .682-.028l.206.206zm.208.64a.512.512 0 0 1-.028.682l-.206.206a.512.512 0 0 1-.682.028l-.206-.206a.512.512 0 0 1 .028-.682l.206-.206a.512.512 0 0 1 .682-.028l.206.206zm1.758-1.55a.512.512 0 0 1 .686.252l.206.411a.512.512 0 0 1-.252.686l-.411.206a.512.512 0 0 1-.686-.252l-.206-.411a.512.512 0 0 1 .252-.686l.411.206zm.686.645a.512.512 0 0 1 .252.686l-.206.411a.512.512 0 0 1-.686.252l-.411-.206a.512.512 0 0 1-.252-.686l.206-.411a.512.512 0 0 1 .686-.252l.411.206zM8.579 14.3a.512.512 0 0 1 .252.686l-.206.411a.512.512 0 0 1-.686.252l-.411-.206a.512.512 0 0 1-.252-.686l.206-.411a.512.512 0 0 1 .686-.252l.411.206zm2.814-2.97a.512.512 0 0 1 .686.252l.206.411a.512.512 0 0 1-.252.686l-.411.206a.512.512 0 0 1-.686-.252l-.206-.411a.512.512 0 0 1 .252-.686l.411.206zm.686.645a.512.512 0 0 1 .252.686l-.206.411a.512.512 0 0 1-.686.252l-.411-.206a.512.512 0 0 1-.252-.686l.206-.411a.512.512 0 0 1 .686-.252l.411.206zM11.803 14.3a.512.512 0 0 1 .252.686l-.206.411a.512.512 0 0 1-.686.252l-.411-.206a.512.512 0 0 1-.252-.686l.206-.411a.512.512 0 0 1 .686-.252l.411.206z"/>
-                  </svg>
-                </button>
-                <button onclick="window.analyzeRecord('${record.id}')" class="text-primary hover:text-secondary p-2 rounded-lg transition hover:bg-primary/10 flex items-center gap-2">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3c7.2 0 9 1.8 9 9s-1.8 9-9 9-9-1.8-9-9 1.8-9 9-9"/><path d="M12 15h.01"/><path d="M12 12V9"/></svg>
-                  Analizar
-                </button>
-              </div>
-            </td>
-          </tr>`;
-      }).join('');
-    }
-
-    function formatRecordForPrompt(record) {
-      let detail = `Sucursal: ${record.branchName || "N/A"}\n`;
-      detail += `Tipo Vehículo: ${record.vehicleType}\n`;
-      detail += `Medida General: ${record.tireSize || 'N/A'}\n`;
-      detail += `Marca/Modelo General: ${record.generalMakeModel}\n`;
-      detail += `Comentarios: "${record.generalComments || 'Ninguno'}"\n\n`;
-      detail += "Estado de Neumáticos:\n";
-      (record.tires || []).forEach(t => {
-        const minSurco = Math.min(t.surco1, t.surco2, t.surco3);
-        const maxSurco = Math.max(t.surco1, t.surco2, t.surco3);
-        const diff = maxSurco - minSurco;
-        detail += `- ${t.position} (${t.makeModel}): ${t.surco1}/${t.surco2}/${t.surco3} mm. Mín: ${minSurco.toFixed(1)}. Δ: ${diff.toFixed(1)} mm.\n`;
-      });
-      detail += "\nLímite legal flota: 3.0 mm.";
-      return detail;
-    }
-
-    window.exportToCsv = function() {
-      if (!window.currentRecords.length) return displayAppMessage('No hay datos para exportar', 'error');
-      let csvContent = "data:text/csv;charset=utf-8,";
-      const superset = Array.from(new Set(Object.values(TIRES_STRUCTURE).flat()));
-      const headers = [
-        "Orden", "Sucursal", "Kilometraje", "Fecha", "Tipo Vehículo", "Marca General", "Medida", "Comentarios", "ID Técnico",
-        ...superset.flatMap(pos => [`Modelo_${pos}`, `Surco1_${pos}`, `Surco2_${pos}`, `Surco3_${pos}`, `FotoURL_${pos}`])
-      ];
-      csvContent += headers.join(";") + "\r\n";
-
-      window.currentRecords.forEach(record => {
-        const tireMap = (record.tires || []).reduce((acc, t) => ({ ...acc, [t.position]: t }), {});
-        const row = [
-          record.orderNumber, record.branchName || 'N/A', record.mileage, record.date, record.vehicleType,
-          record.generalMakeModel, record.tireSize, `"${(record.generalComments || '').replace(/"/g, '""')}"`, record.technicianId,
-          ...superset.flatMap(pos => {
-            const t = tireMap[pos];
-            return [t ? t.makeModel : '', t ? t.surco1 : '', t ? t.surco2 : '', t ? t.surco3 : '', t && t.photoURL !== 'N/A' ? t.photoURL : ''];
-          })
-        ];
-        csvContent += row.join(";") + "\r\n";
-      });
-
-      const encodedUri = encodeURI(csvContent);
-      const link = document.createElement("a");
-      link.setAttribute("href", encodedUri);
-      link.setAttribute("download", `registros_neumaticos_${new Date().toISOString().slice(0, 10)}.csv`);
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      displayAppMessage('Exportación a CSV completada.', 'success');
-    }
-    
-    // === INICIO DE LA APP ===
-    window.onload = function() {
-      initializeAppCore().then(() => {
-        const makeModelSelect = document.getElementById('makeModel');
-        const tireSizeSelect = document.getElementById('tireSize');
-        const branchSelect = document.getElementById('branchName');
-        PREDEFINED_MODELS.forEach(m => makeModelSelect.insertAdjacentHTML('beforeend', `<option value="${m}">${m}</option>`));
-        PREDEFINED_SIZES.forEach(s => tireSizeSelect.insertAdjacentHTML('beforeend', `<option value="${s}">${s}</option>`));
-        BRANCHES.forEach(b => branchSelect.insertAdjacentHTML('beforeend', `<option value="${b}">${b}</option>`));
-        
-        window.switchTab('guide');
-      });
-    }
-  </script>
-</head>
-
-<body class="bg-background">
-  <div id="app-container" class="flex flex-col">
-    <!-- Encabezado Fijo -->
-    <header class="bg-white shadow-md sticky top-0 z-10">
-      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-        <div class="flex justify-between items-center">
-          <h1 class="text-2xl font-bold text-gray-800">
-            <span class="text-primary">Flota</span> TRACK
-          </h1>
-          <div class="flex items-center space-x-4">
-            <span id="firebaseErrorDisplay" class="text-sm font-medium text-red-600"></span>
-            <span id="userIdDisplay" class="text-sm font-medium text-gray-600"></span>
-          </div>
-        </div>
-      </div>
-      <!-- Navegación por Pestañas -->
-      <nav class="border-t border-gray-200">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div class="flex space-x-4 sm:space-x-8 -mb-px">
-            <button id="tab-button-guide" onclick="switchTab('guide')" type="button" class="tab-button">Guía Rápida</button>
-            <button id="tab-button-register" onclick="switchTab('register')" type="button" class="tab-button">Registrar</button>
-            <button id="tab-button-records" onclick="switchTab('records')" type="button" class="tab-button">Historial</button>
-          </div>
-        </div>
-      </nav>
-    </header>
-
-    <!-- Contenido Principal -->
-    <main class="flex-grow max-w-4xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
-      <!-- Mensajes Globales de la App -->
-      <div id="appMessage" class="hidden opacity-0 max-h-0 transition-all duration-300"></div>
-
-      <!-- Contenido de Pestañas -->
-      <div id="tab-content-guide" class="hidden">
-        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
-            <h2 class="text-xl font-bold text-gray-800 mb-4">Bienvenido a Flota TRACK</h2>
-            <p class="text-gray-600 mb-6">Esta herramienta te permite registrar y analizar el estado de los surcos de los neumáticos de tu flota. Sigue estos pasos para un uso correcto:</p>
-            <ol class="list-decimal list-inside space-y-3 text-gray-700">
-                <li><strong>Registrar Medición:</strong> Ve a la pestaña "Registrar", completa los datos del vehículo y mide los 3 surcos principales de cada neumático.</li>
-                <li><strong>Evaluar:</strong> Presiona "Evaluar Medición" para obtener un diagnóstico inmediato sobre el estado y las acciones recomendadas.</li>
-                <li><strong>Guardar:</strong> Si la evaluación es correcta, guarda el registro. Quedará almacenado en el "Historial".</li>
-                <li><strong>Analizar con IA:</strong> En el historial, usa el botón "✨ Analizar" para que un experto virtual te dé recomendaciones avanzadas sobre mantenimiento y rotación.</li>
-            </ol>
-             <div class="mt-8 p-4 bg-primary/10 border-l-4 border-primary rounded-r-lg">
-                <h3 class="font-semibold text-primary mb-2">Consejo de longevidad</h3>
-                <p id="randomTip" class="text-sm text-gray-700"></p>
-            </div>
-        </div>
-      </div>
-
-      <div id="tab-content-register" class="hidden">
-        <form id="registrationForm" onsubmit="handleReview(event)">
-          <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200 mb-6">
-            <h3 class="text-xl font-bold text-gray-800 mb-4">1. Datos Generales del Vehículo</h3>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label for="branchName" class="block text-sm font-medium text-gray-700 mb-1">Sucursal</label>
-                <select id="branchName" name="branchName" class="form-control" required><option value="" disabled selected>Selecciona una sucursal...</option></select>
-              </div>
-              <div>
-                <label for="orderNumber" class="block text-sm font-medium text-gray-700 mb-1">Número de Orden</label>
-                <input type="number" id="orderNumber" name="orderNumber" class="form-control" placeholder="Ej: 12345" required />
-              </div>
-              <div>
-                <label for="mileage" class="block text-sm font-medium text-gray-700 mb-1">Kilometraje</label>
-                <input type="number" id="mileage" name="mileage" class="form-control" placeholder="Ej: 85000" required />
-              </div>
-              <div>
-                <label for="date" class="block text-sm font-medium text-gray-700 mb-1">Fecha de Medición</label>
-                <input type="date" id="date" name="date" class="form-control" required />
-              </div>
-              <div>
-                <label for="tireSize" class="block text-sm font-medium text-gray-700 mb-1">Medida General</label>
-                <select id="tireSize" name="tireSize" class="form-control" required><option value="" disabled selected>Selecciona una medida...</option></select>
-              </div>
-              <div>
-                <label for="makeModel" class="block text-sm font-medium text-gray-700 mb-1">Marca/Modelo General</label>
-                <select id="makeModel" name="makeModel" class="form-control" required><option value="" disabled selected>Selecciona una marca...</option></select>
-              </div>
-               <div class="md:col-span-2">
-                <label for="generalComments" class="block text-sm font-medium text-gray-700 mb-1">Comentarios Generales</label>
-                <textarea id="generalComments" name="generalComments" rows="2" class="form-control" placeholder="Observaciones sobre el vehículo, alineación, etc."></textarea>
-              </div>
-            </div>
-          </div>
-
-          <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200 mb-6">
-            <h3 class="text-xl font-bold text-gray-800 mb-4">2. Selección y Medición</h3>
-             <div>
-                <label for="vehicleType" class="block text-sm font-medium text-gray-700 mb-1">Tipo de Vehículo</label>
-                <select id="vehicleType" name="vehicleType" class="form-control" onchange="generateTireInputs()" required>
-                  <option value="" disabled selected>Selecciona un tipo para generar los campos...</option>
-                  <option value="Bus">Bus</option>
-                  <option value="Taxibus">Taxibus</option>
-                  <option value="Minibús">Minibús</option>
-                  <option value="Minibús DR (Doble Rodado)">Minibús DR (Doble Rodado)</option>
-                  <option value="Camioneta">Camioneta</option>
-                </select>
-              </div>
-          </div>
-
-          <div id="tireInputsContainer" class="mb-6"></div>
-          
-          <div id="reviewFeedback" class="mb-6"></div>
-
-          <div class="flex items-center justify-end space-x-4">
-            <button id="reviewButton" type="submit" class="px-6 py-3 bg-accent text-gray-800 font-bold rounded-lg shadow-sm hover:bg-yellow-400 transition disabled:bg-gray-300 disabled:cursor-not-allowed">
-              Evaluar Medición
-            </button>
-            <button id="saveButton" type="button" onclick="handleSave()" class="px-6 py-3 bg-primary text-white font-bold rounded-lg shadow-sm hover:bg-secondary transition disabled:bg-green-800 disabled:cursor-not-allowed" disabled>
-              Guardar Registro
-            </button>
-          </div>
-        </form>
-      </div>
-
-      <div id="tab-content-records" class="hidden">
-         <div class="flex justify-between items-center mb-4">
-            <h2 class="text-xl font-bold text-gray-800">Historial de Registros</h2>
-            <button onclick="exportToCsv()" class="px-4 py-2 bg-secondary text-white font-semibold text-sm rounded-lg shadow-sm hover:bg-primary transition">
-              Exportar a CSV
-            </button>
-        </div>
-        <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-x-auto">
-            <table class="w-full text-left">
-                <thead class="bg-gray-50 border-b">
-                    <tr>
-                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Orden</th>
-                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Sucursal</th>
-                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Vehículo</th>
-                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">KM</th>
-                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Fecha</th>
-                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Surco Mín.</th>
-                        <th class="px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider text-right">Acciones</th>
+                    <tr class="bg-white">
+                        <th class="px-4 py-2">
+                            <input id="orderFilter" type="text" placeholder="Buscar orden" class="filter-input bg-white" oninput="applyFiltersAndDisplay()" />
+                        </th>
+                        <th class="px-4 py-2">
+                            <select id="branchColumnFilter" class="filter-input bg-white" onchange="applyFiltersAndDisplay()">
+                                <option value="">Todas</option>
+                            </select>
+                        </th>
+                        <th class="px-4 py-2">
+                            <input id="vehicleFilter" type="text" placeholder="Buscar vehículo" class="filter-input bg-white" oninput="applyFiltersAndDisplay()" />
+                        </th>
+                        <th class="px-4 py-2">
+                            <input id="kmFilter" type="text" placeholder="Filtrar km" class="filter-input bg-white" oninput="applyFiltersAndDisplay()" />
+                        </th>
+                        <th class="px-4 py-2">
+                            <input id="dateFilter" type="date" class="filter-input bg-white" onchange="applyFiltersAndDisplay()" />
+                        </th>
+                        <th class="px-4 py-2">
+                            <input id="surcoFilter" type="text" placeholder="Mínimo mm" class="filter-input bg-white" oninput="applyFiltersAndDisplay()" />
+                        </th>
+                        <th class="px-4 py-2">
+                            <input id="kpmmFilter" type="text" placeholder="Filtrar kpmm" class="filter-input bg-white" oninput="applyFiltersAndDisplay()" />
+                        </th>
+                        <th class="px-4 py-2"></th>
                     </tr>
                 </thead>
                 <tbody id="recordsTableBody">

--- a/index.html
+++ b/index.html
@@ -45,17 +45,32 @@
         border-color: #059669;
         box-shadow: 0 0 0 2px rgba(5, 150, 105, 0.2);
     }
+    .input-valid {
+        border-color: #059669 !important;
+        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.15) !important;
+    }
+    .input-invalid {
+        border-color: #dc2626 !important;
+        box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.2) !important;
+    }
+    .readonly-input {
+        background-color: #f3f4f6;
+        color: #4b5563;
+        cursor: not-allowed;
+    }
   </style>
 
   <!-- Librerías para generar PDF y Excel -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
 
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
     import { getAuth, onAuthStateChanged, signInAnonymously } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
-    import { getFirestore, addDoc, onSnapshot, collection, query, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+    import { getFirestore, addDoc, onSnapshot, collection, query, serverTimestamp, doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+    import { getStorage, ref as storageRef, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 
     // === CONFIGURACIÓN ===
     const GEMINI_MODEL = "gemini-2.5-flash-preview-05-20";
@@ -73,6 +88,45 @@
       'Michelin X Multiway 3D XZE', 'Pirelli FH:01 Energy', 'Bridgestone R260', 'Dunlop SP338', 'Goodyear KMAX S', 'Continental HT3', 'Hankook SmartFlex AH31', 'Westlake CB867', 'Sailun S701'
     ];
     const PREDEFINED_SIZES = ['225/75R16', '245/70R19.5', '275/80R22.5', '295/80R22.5', '315/80R22.5', '11R22.5', '12R22.5', '10.00R20'];
+    const FLEET_SHEET_NAME = 'Flota Verschae';
+    const FLEET_DATA_STORAGE_KEY = 'flota-track-fleet-dataset-v1';
+    const FLEET_DATA_META_STORAGE_KEY = 'flota-track-fleet-dataset-meta-v1';
+    const FLEET_STORAGE_PATH = 'fleet/catalog.xlsx';
+    const FLEET_METADATA_DOC_ID = 'fleetCatalog';
+    const ORDER_KEYWORDS = ['orden', 'n° orden', 'nº orden', 'numero orden', 'orden vehículo', 'orden vehiculo'];
+    const MOBILE_KEYWORDS = ['móvil', 'movil', 'n° movil', 'nº movil', 'nro movil', 'numero movil'];
+    const PLATE_KEYWORDS = ['patente', 'placa', 'matricula'];
+    const MILEAGE_KEYWORDS = ['kilometraje', 'km', 'kilometros', 'kilómetros', 'odometro', 'odómetro', 'última mantencion', 'ultima mantencion', 'kms de mant.'];
+    const TYPE_KEYWORDS = ['tipo de transporte', 'tipo'];
+    const STATUS_KEYWORDS = ['status', 'estado mp', 'estado'];
+    const MAKE_KEYWORDS = ['marca'];
+    const MODEL_KEYWORDS = ['modelo'];
+    const YEAR_KEYWORDS = ['año', 'ano'];
+    const ZONE_KEYWORDS = ['zonal', 'zona'];
+    const LAST_MILEAGE_KEYWORDS = ['ultimo kilometraje', 'último kilometraje'];
+    const LAST_MILEAGE_DATE_KEYWORDS = ['fecha ultimo kilometraje', 'fecha último kilometraje'];
+    const DISTANCE_TRAVELED_KEYWORDS = ['km. recorrido', 'km recorrido'];
+    const LAST_MAINTENANCE_KM_KEYWORDS = ['km. última mantencion', 'km ultima mantencion'];
+    const LAST_MAINTENANCE_DATE_KEYWORDS = ['fecha última mantencion', 'fecha ultima mantencion'];
+    const MAINTENANCE_PLAN_KEYWORDS = ['pauta última mantencion', 'pauta ultima mantencion'];
+    const MAINTENANCE_KM_KEYWORDS = ['kms de mant.', 'kms de mantencion', 'km mantencion'];
+    const REMAINING_KM_KEYWORDS = ['falta', 'faltante', 'km restante'];
+    const MAINTENANCE_STATUS_KEYWORDS = ['estado mp', 'estado mantencion', 'estado mantenimiento'];
+    const FLEET_FALLBACK_INDEX = { order: 2, mobile: 2, plate: 3, mileage: 13 };
+    const CATALOG_STORAGE_KEY = 'flota-track-catalog';
+    const DEFAULT_KM_ALERT_THRESHOLD = 2000;
+    const MAINTENANCE_STATUS_LABELS = {
+      overdue: 'Mantención vencida',
+      upcoming: 'Mantención próxima',
+      ok: 'Mantención vigente',
+      unknown: 'Sin estado'
+    };
+    const MAINTENANCE_STATUS_PRIORITY = new Map([
+      [MAINTENANCE_STATUS_LABELS.overdue, 0],
+      [MAINTENANCE_STATUS_LABELS.upcoming, 1],
+      [MAINTENANCE_STATUS_LABELS.ok, 2],
+      [MAINTENANCE_STATUS_LABELS.unknown, 3]
+    ]);
     const longevityTips = [
       "Mantén la <strong>presión correcta</strong> semanalmente. La subinflación es el principal asesino de neumáticos.",
       "Realiza la <strong>rotación</strong> cada 10–12 mil km para asegurar un desgaste uniforme.",
@@ -85,12 +139,1309 @@
     ];
 
     // === ESTADO GLOBAL DE LA APLICACIÓN ===
-    let app = null, db = null, auth = null;
+    let app = null, db = null, auth = null, storage = null;
     let currentUserId = null;
     let authReady = false;
     let unsubscribeRecords = null;
     window.currentRecords = [];
     window.pendingReviewData = null;
+    let fleetLookup = new Map();
+    let fleetEntries = [];
+    let fleetLoadStatus = 'idle';
+    let fleetLoadError = '';
+    let fleetDatasetMeta = null;
+    let customModels = [];
+    let customSizes = [];
+    let maintenanceStatusChart = null;
+    let dashboardStatusFilter = 'Todos';
+    let dashboardBranchFilter = 'Todas';
+    let dashboardCachedEntries = [];
+
+    function normalizeOrderKey(value) {
+      if (value === null || value === undefined) return '';
+      return String(value).trim().toUpperCase().replace(/\s+/g, '');
+    }
+
+    function findColumnIndex(headers, keywords, fallbackIndex) {
+      if (!Array.isArray(headers)) return fallbackIndex;
+      const index = headers.findIndex((header) => {
+        const normalizedHeader = String(header || '').trim().toLowerCase();
+        return keywords.some(keyword => normalizedHeader.includes(keyword));
+      });
+      return index !== -1 ? index : fallbackIndex;
+    }
+
+    function safeCellValue(row, index) {
+      if (!Array.isArray(row) || typeof index !== 'number' || index < 0) return '';
+      if (index >= row.length) return '';
+      const value = row[index];
+      if (value === null || value === undefined) return '';
+      return String(value).trim();
+    }
+
+    function getCellValue(row, index) {
+      if (!Array.isArray(row) || typeof index !== 'number' || index < 0) return null;
+      if (index >= row.length) return null;
+      return row[index];
+    }
+
+    function parseNumeric(value) {
+      if (value === null || value === undefined || value === '') return null;
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+      const normalized = String(value)
+        .trim()
+        .replace(/\s+/g, '')
+        .replace(/\.(?=\d{3}(?:\D|$))/g, '')
+        .replace(/,/g, '.')
+        .replace(/[^0-9.-]/g, '');
+      if (!normalized || normalized === '-' || normalized === '.') return null;
+      const parsed = parseFloat(normalized);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function formatDateValue(value) {
+      if (value === null || value === undefined || value === '') return '';
+      if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? '' : value.toISOString().slice(0, 10);
+      }
+      if (typeof value === 'number' && typeof XLSX !== 'undefined' && XLSX.SSF && XLSX.SSF.parse_date_code) {
+        const parsed = XLSX.SSF.parse_date_code(value);
+        if (parsed) {
+          const iso = new Date(Date.UTC(parsed.y, parsed.m - 1, parsed.d));
+          return Number.isNaN(iso.getTime()) ? '' : iso.toISOString().slice(0, 10);
+        }
+      }
+      const stringValue = String(value).trim();
+      if (!stringValue) return '';
+      const asDate = new Date(stringValue);
+      if (!Number.isNaN(asDate.getTime())) {
+        return asDate.toISOString().slice(0, 10);
+      }
+      return stringValue;
+    }
+
+    function parseDateCell(row, index) {
+      const raw = getCellValue(row, index);
+      return formatDateValue(raw);
+    }
+
+    function parseNumericCell(row, index) {
+      const raw = getCellValue(row, index);
+      const parsed = parseNumeric(raw);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function parseStringCell(row, index) {
+      const raw = getCellValue(row, index);
+      if (raw === null || raw === undefined) return '';
+      return String(raw).trim();
+    }
+
+    function normalizeTextValue(value) {
+      if (value === null || value === undefined) return '';
+      const text = String(value).trim();
+      return text ? text.replace(/\s+/g, ' ') : '';
+    }
+
+    function normalizeZoneValue(value) {
+      return normalizeTextValue(value);
+    }
+
+    function normalizeMaintenanceStatusValue(value) {
+      return normalizeTextValue(value);
+    }
+
+    function canonicalizeMaintenanceStatusText(value) {
+      const normalized = normalizeMaintenanceStatusValue(value);
+      if (!normalized) return '';
+      const ascii = typeof normalized.normalize === 'function'
+        ? normalized.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+        : normalized;
+      const lower = ascii.toLowerCase();
+      if (['na', 'n/a', 'pendiente', 'pendiente de ingreso', 'sin dato', 'sin estado', '-'].some(token => lower === token)) {
+        return '';
+      }
+      if (lower.includes('venc')) return MAINTENANCE_STATUS_LABELS.overdue;
+      if (lower.includes('crit') || lower.includes('rojo')) return MAINTENANCE_STATUS_LABELS.overdue;
+      if (lower.includes('prox')) return MAINTENANCE_STATUS_LABELS.upcoming;
+      if (lower.includes('pend') || lower.includes('prog')) return MAINTENANCE_STATUS_LABELS.upcoming;
+      if (lower.includes('alert')) return MAINTENANCE_STATUS_LABELS.upcoming;
+      if (lower.includes('vigent') || lower.includes('ok')) return MAINTENANCE_STATUS_LABELS.ok;
+      if (lower.includes('realiz') || lower.includes('compl') || lower.includes('verde')) return MAINTENANCE_STATUS_LABELS.ok;
+      return normalized;
+    }
+
+    function inferStatusFromKm(kmRemaining) {
+      if (!Number.isFinite(kmRemaining)) return '';
+      if (kmRemaining <= 0) return MAINTENANCE_STATUS_LABELS.overdue;
+      if (kmRemaining <= DEFAULT_KM_ALERT_THRESHOLD) return MAINTENANCE_STATUS_LABELS.upcoming;
+      return MAINTENANCE_STATUS_LABELS.ok;
+    }
+
+    function computeKmRemaining(remaining, mileage, lastMileage, maintenanceKm, lastMaintenanceKm) {
+      const candidates = [];
+      if (Number.isFinite(remaining)) {
+        candidates.push(Math.round(remaining));
+      }
+      const mileageValue = Number.isFinite(mileage) ? mileage : (Number.isFinite(lastMileage) ? lastMileage : null);
+      if (mileageValue !== null) {
+        if (Number.isFinite(maintenanceKm)) {
+          candidates.push(Math.round(maintenanceKm - mileageValue));
+        }
+        if (Number.isFinite(lastMaintenanceKm)) {
+          candidates.push(Math.round(lastMaintenanceKm - mileageValue));
+        }
+      }
+      const sanitized = candidates.filter(value => Number.isFinite(value) && Math.abs(value) <= 1e6);
+      return sanitized.length ? sanitized[0] : null;
+    }
+
+    function getKmRemainingValue(entry) {
+      if (!entry) return null;
+      if (typeof entry.kmRemaining === 'number' && Number.isFinite(entry.kmRemaining)) {
+        return entry.kmRemaining;
+      }
+      return computeKmRemaining(
+        parseNumeric(entry.kmRemaining ?? entry.falta),
+        parseNumeric(entry.mileage ?? entry.lastMileage ?? entry.maintenanceKm ?? entry.lastMaintenanceKm),
+        parseNumeric(entry.lastMileage ?? entry.ultimoKilometraje ?? entry.lastMileageValue),
+        parseNumeric(entry.maintenanceKm ?? entry.kmsMant),
+        parseNumeric(entry.lastMaintenanceKm ?? entry.kmUltimaMantencion)
+      );
+    }
+
+    function deriveMaintenanceStatus(entry) {
+      if (!entry) return MAINTENANCE_STATUS_LABELS.unknown;
+      const rawStatus = entry.maintenanceStatusRaw || entry.maintenanceStatus || entry.status || '';
+      const canonical = canonicalizeMaintenanceStatusText(rawStatus);
+      if (canonical && canonical !== MAINTENANCE_STATUS_LABELS.unknown) {
+        return canonical;
+      }
+      const kmRemaining = getKmRemainingValue(entry);
+      const inferred = inferStatusFromKm(kmRemaining);
+      if (inferred) return inferred;
+      return canonical || MAINTENANCE_STATUS_LABELS.unknown;
+    }
+
+    function getZoneLabel(entry) {
+      const zone = entry ? normalizeZoneValue(entry.zone || entry.zonal || '') : '';
+      return zone || 'Sin sucursal';
+    }
+
+    function getMaintenanceStatus(entry) {
+      if (!entry) return MAINTENANCE_STATUS_LABELS.unknown;
+      const direct = canonicalizeMaintenanceStatusText(
+        entry.maintenanceStatus || entry.maintenanceStatusRaw || entry.status || entry.statusGeneral || ''
+      );
+      if (direct && direct !== MAINTENANCE_STATUS_LABELS.unknown) {
+        return direct;
+      }
+      const derived = deriveMaintenanceStatus(entry);
+      return derived || MAINTENANCE_STATUS_LABELS.unknown;
+    }
+
+    function convertFirebaseTimestampToIso(value) {
+      if (!value) return '';
+      if (typeof value === 'string') {
+        const normalized = formatDateValue(value);
+        return normalized || '';
+      }
+      if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? '' : value.toISOString();
+      }
+      if (typeof value.toDate === 'function') {
+        const date = value.toDate();
+        return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+      }
+      if (typeof value.seconds === 'number') {
+        const millis = value.seconds * 1000 + Math.floor((value.nanoseconds || 0) / 1e6);
+        const date = new Date(millis);
+        return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+      }
+      return '';
+    }
+
+    function resolveAutofillMileage(entry) {
+      if (!entry) return null;
+      const candidates = [entry.mileage, entry.lastMileage, entry.maintenanceKm, entry.lastMaintenanceKm];
+      for (const candidate of candidates) {
+        if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+          return Math.round(candidate);
+        }
+        const parsed = parseNumeric(candidate);
+        if (Number.isFinite(parsed)) {
+          return Math.round(parsed);
+        }
+      }
+      return null;
+    }
+
+    function loadCatalogFromStorage() {
+      try {
+        const stored = localStorage.getItem(CATALOG_STORAGE_KEY);
+        if (!stored) return;
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed.models)) customModels = parsed.models.filter(Boolean);
+        if (Array.isArray(parsed.sizes)) customSizes = parsed.sizes.filter(Boolean);
+      } catch (error) {
+        console.warn('No se pudo cargar el catálogo personalizado:', error);
+        customModels = [];
+        customSizes = [];
+      }
+    }
+
+    function saveCatalogToStorage() {
+      const payload = {
+        models: customModels.filter(Boolean),
+        sizes: customSizes.filter(Boolean)
+      };
+      try {
+        localStorage.setItem(CATALOG_STORAGE_KEY, JSON.stringify(payload));
+      } catch (error) {
+        console.warn('No se pudo guardar el catálogo personalizado:', error);
+      }
+    }
+
+    function getAvailableMakeModels() {
+      return Array.from(new Set([...PREDEFINED_MODELS, ...customModels.filter(Boolean)])).sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    }
+
+    function getAvailableTireSizes() {
+      return Array.from(new Set([...PREDEFINED_SIZES, ...customSizes.filter(Boolean)])).sort((a, b) => a.localeCompare(b, 'es', { numeric: true, sensitivity: 'base' }));
+    }
+
+    function getMakeModelOptionsMarkup() {
+      return getAvailableMakeModels().map((model) => `<option value="${model}">${model}</option>`).join('');
+    }
+
+    function refreshCatalogSelects() {
+      const makeModelSelect = document.getElementById('makeModel');
+      if (makeModelSelect) {
+        const previous = makeModelSelect.value;
+        makeModelSelect.innerHTML = '<option value="" disabled selected>Selecciona una marca...</option>' + getMakeModelOptionsMarkup();
+        if (previous && getAvailableMakeModels().includes(previous)) {
+          makeModelSelect.value = previous;
+        }
+      }
+
+      const tireSizeSelect = document.getElementById('tireSize');
+      if (tireSizeSelect) {
+        const previousSize = tireSizeSelect.value;
+        tireSizeSelect.innerHTML = '<option value="" disabled selected>Selecciona una medida...</option>' + getAvailableTireSizes().map((size) => `<option value="${size}">${size}</option>`).join('');
+        if (previousSize && getAvailableTireSizes().includes(previousSize)) {
+          tireSizeSelect.value = previousSize;
+        }
+      }
+
+      updatePerTireModelSelects();
+    }
+
+    function updatePerTireModelSelects() {
+      const optionsMarkup = getMakeModelOptionsMarkup();
+      document.querySelectorAll('select[id^="tireMakeModel-"]').forEach((select) => {
+        const previous = select.value;
+        select.innerHTML = '<option value="" selected>Usar marca general del formulario</option>' + optionsMarkup;
+        if (previous && getAvailableMakeModels().includes(previous)) {
+          select.value = previous;
+        }
+      });
+    }
+
+    function renderCatalogLists() {
+      const modelList = document.getElementById('customModelList');
+      if (modelList) {
+        if (customModels.length === 0) {
+          modelList.innerHTML = '<p class="text-sm text-gray-500">Aún no registras modelos personalizados.</p>';
+        }
+        else {
+          modelList.innerHTML = customModels.map((item) => `<span class="px-3 py-1 bg-primary/10 text-primary rounded-full text-xs font-semibold">${item}</span>`).join(' ');
+        }
+      }
+      const sizeList = document.getElementById('customSizeList');
+      if (sizeList) {
+        if (customSizes.length === 0) {
+          sizeList.innerHTML = '<p class="text-sm text-gray-500">Aún no registras medidas personalizadas.</p>';
+        }
+        else {
+          sizeList.innerHTML = customSizes.map((item) => `<span class="px-3 py-1 bg-secondary/10 text-secondary rounded-full text-xs font-semibold">${item}</span>`).join(' ');
+        }
+      }
+    }
+
+    function showAdminFeedback(message, type = 'info') {
+      const container = document.getElementById('adminFeedback');
+      if (!container) return;
+      const typeClasses = {
+        success: 'text-green-600',
+        error: 'text-red-600',
+        info: 'text-gray-600',
+        warning: 'text-amber-600'
+      };
+      container.textContent = message;
+      container.className = `mt-4 text-sm font-medium ${typeClasses[type] || typeClasses.info}`;
+    }
+
+    window.handleAdminAddModel = function(event) {
+      event.preventDefault();
+      const input = document.getElementById('newModel');
+      if (!input) return;
+      const value = input.value.trim();
+      if (!value) {
+        showAdminFeedback('Ingresa una marca o modelo válido.', 'error');
+        return;
+      }
+      if (getAvailableMakeModels().some(item => item.toLowerCase() === value.toLowerCase())) {
+        showAdminFeedback('Ese modelo ya existe en el catálogo.', 'warning');
+        input.value = '';
+        return;
+      }
+      customModels.push(value);
+      customModels = Array.from(new Set(customModels));
+      saveCatalogToStorage();
+      refreshCatalogSelects();
+      renderCatalogLists();
+      showAdminFeedback(`Modelo "${value}" agregado correctamente.`, 'success');
+      input.value = '';
+    };
+
+    window.handleAdminAddSize = function(event) {
+      event.preventDefault();
+      const input = document.getElementById('newSize');
+      if (!input) return;
+      const value = input.value.trim().toUpperCase();
+      if (!value) {
+        showAdminFeedback('Ingresa una medida válida.', 'error');
+        return;
+      }
+      if (getAvailableTireSizes().some(item => item.toLowerCase() === value.toLowerCase())) {
+        showAdminFeedback('Esa medida ya existe en el catálogo.', 'warning');
+        input.value = '';
+        return;
+      }
+      customSizes.push(value);
+      customSizes = Array.from(new Set(customSizes));
+      saveCatalogToStorage();
+      refreshCatalogSelects();
+      renderCatalogLists();
+      showAdminFeedback(`Medida "${value}" agregada correctamente.`, 'success');
+      input.value = '';
+    };
+
+    function attachOrderNumberHandlers() {
+      const orderInput = document.getElementById('orderNumber');
+      if (!orderInput) return;
+      orderInput.addEventListener('input', handleOrderNumberInput);
+      orderInput.addEventListener('change', handleOrderNumberInput);
+      orderInput.addEventListener('blur', handleOrderNumberInput);
+    }
+
+    function setOrderInputState(status, error) {
+      fleetLoadStatus = status;
+      fleetLoadError = error ? String(error) : '';
+      const orderInput = document.getElementById('orderNumber');
+      const feedback = document.getElementById('orderNumberFeedback');
+      if (!orderInput || !feedback) return;
+      if (status === 'loading') {
+        orderInput.placeholder = 'Buscando catálogo de flota...';
+        feedback.textContent = 'Restaurando la hoja "Flota Verschae" almacenada en este navegador...';
+        feedback.className = 'mt-1 text-xs text-gray-500';
+      } else if (status === 'ready') {
+        orderInput.placeholder = 'Escribe o selecciona una orden de la flota';
+        if (!orderInput.value.trim()) {
+          feedback.textContent = 'Selecciona la orden desde la planilla para evitar errores.';
+          feedback.className = 'mt-1 text-xs text-gray-500';
+        }
+      } else if (status === 'error') {
+        orderInput.placeholder = 'Ingresa el número de orden';
+        feedback.textContent = error ? String(error) : 'No se pudo validar automáticamente. Ingresa el N° manualmente y verifica en la planilla.';
+        feedback.className = 'mt-1 text-xs text-amber-600';
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+      }
+    }
+
+    function refreshOrderDatalist() {
+      const datalist = document.getElementById('orderNumberOptions');
+      if (!datalist) return;
+      datalist.innerHTML = '';
+      if (!fleetEntries.length) return;
+      const sorted = [...fleetEntries].sort((a, b) => compareOrderNumbers(a.orderNumber, b.orderNumber));
+      sorted.forEach((entry) => {
+        const value = entry.orderNumber || entry.normalizedOrder;
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = entry.plate ? `${value} · ${entry.plate}` : value;
+        datalist.appendChild(option);
+      });
+    }
+
+    function handleOrderNumberInput() {
+      const orderInput = document.getElementById('orderNumber');
+      const plateInput = document.getElementById('vehiclePlate');
+      const feedback = document.getElementById('orderNumberFeedback');
+      const mileageInput = document.getElementById('mileage');
+      if (!orderInput || !feedback) return;
+      const rawValue = orderInput.value || '';
+      const normalized = normalizeOrderKey(rawValue);
+
+      if (!rawValue.trim()) {
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+        if (feedback) {
+          feedback.textContent = fleetLoadStatus === 'ready' ? 'Selecciona la orden desde la planilla para evitar errores.' : feedback.textContent;
+          feedback.className = 'mt-1 text-xs text-gray-500';
+        }
+        if (plateInput) plateInput.value = '';
+        if (mileageInput) mileageInput.value = '';
+        return;
+      }
+
+      if (fleetLookup.has(normalized)) {
+        const match = fleetLookup.get(normalized);
+        if (match) {
+          orderInput.value = match.orderNumber || rawValue.trim();
+          orderInput.classList.add('input-valid');
+          orderInput.classList.remove('input-invalid');
+          orderInput.setCustomValidity('');
+          if (feedback) {
+            feedback.textContent = match.plate ? `Patente encontrada: ${match.plate}` : 'Orden validada en la flota.';
+            feedback.className = 'mt-1 text-xs text-green-600';
+          }
+          if (plateInput) {
+            plateInput.value = match.plate || 'Sin patente registrada';
+          }
+          if (mileageInput) {
+            const resolvedMileage = resolveAutofillMileage(match);
+            if (resolvedMileage !== null) {
+              mileageInput.value = resolvedMileage;
+            }
+          }
+          return;
+        }
+      }
+
+      if (fleetLoadStatus === 'error') {
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+        if (feedback) {
+          feedback.textContent = 'No se pudo validar con la planilla. Verifica manualmente el N° de móvil (columna C).';
+          feedback.className = 'mt-1 text-xs text-amber-600';
+        }
+      } else {
+        orderInput.classList.add('input-invalid');
+        orderInput.classList.remove('input-valid');
+        orderInput.setCustomValidity('Número de móvil no encontrado en la hoja "Flota Verschae". Revisa la columna C.');
+        if (feedback) {
+          feedback.textContent = 'Número incorrecto. Confirma el N° de móvil (columna C) en la planilla.';
+          feedback.className = 'mt-1 text-xs text-red-600';
+        }
+      }
+      if (plateInput) plateInput.value = '';
+      if (mileageInput) mileageInput.value = '';
+    }
+
+    function resetOrderAutofill() {
+      const orderInput = document.getElementById('orderNumber');
+      const plateInput = document.getElementById('vehiclePlate');
+      const feedback = document.getElementById('orderNumberFeedback');
+      if (orderInput) {
+        orderInput.classList.remove('input-valid', 'input-invalid');
+        orderInput.setCustomValidity('');
+        orderInput.value = '';
+      }
+      if (plateInput) plateInput.value = '';
+      if (feedback) {
+        feedback.textContent = fleetLoadStatus === 'ready' ? 'Selecciona la orden desde la planilla para evitar errores.' : 'Número de orden del vehículo.';
+        feedback.className = 'mt-1 text-xs text-gray-500';
+      }
+    }
+
+    async function fetchFleetMetadataFromCloud() {
+      if (!db) return null;
+      try {
+        const metadataRef = doc(db, 'artifacts', appId, 'meta', FLEET_METADATA_DOC_ID);
+        const snapshot = await getDoc(metadataRef);
+        if (!snapshot.exists()) return null;
+        const data = snapshot.data() || {};
+        const updatedAtIso = convertFirebaseTimestampToIso(data.updatedAt) || convertFirebaseTimestampToIso(data.updatedAtClient);
+        return {
+          sourceName: data.sourceName || 'Firebase Storage',
+          updatedAt: updatedAtIso || new Date().toISOString(),
+          fileSize: typeof data.fileSize === 'number' ? data.fileSize : null,
+          contentType: data.contentType || '',
+          uploadedBy: data.uploadedBy || ''
+        };
+      } catch (error) {
+        console.warn('No se pudo recuperar la metadata del catálogo de flota:', error);
+        return null;
+      }
+    }
+
+    async function fetchFleetDatasetFromCloud() {
+      if (!storage) {
+        throw new Error('Firebase Storage no está inicializado.');
+      }
+      const fileReference = storageRef(storage, FLEET_STORAGE_PATH);
+      const downloadUrl = await getDownloadURL(fileReference);
+      const response = await fetch(downloadUrl, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Error ${response.status} al descargar la planilla de flota.`);
+      }
+      const arrayBuffer = await response.arrayBuffer();
+      const entries = parseFleetWorkbook(arrayBuffer);
+      const meta = await fetchFleetMetadataFromCloud();
+      return { entries, meta: meta || { sourceName: 'Firebase Storage', updatedAt: new Date().toISOString() } };
+    }
+
+    async function loadFleetDataset() {
+      setOrderInputState('loading');
+      showFleetUploadFeedback('Sincronizando catálogo desde Firebase...', 'info');
+      try {
+        const result = await fetchFleetDatasetFromCloud();
+        if (result && Array.isArray(result.entries) && result.entries.length) {
+          applyFleetDataset(result.entries, { meta: result.meta || {} });
+          showFleetUploadFeedback('Catálogo sincronizado desde Firebase Storage.', 'success');
+          return;
+        }
+        throw new Error('El archivo de flota no contiene registros válidos.');
+      } catch (cloudError) {
+        console.warn('No se pudo sincronizar el catálogo de flota desde Firebase:', cloudError);
+        const stored = restoreFleetDatasetFromStorage();
+        if (stored && Array.isArray(stored.entries) && stored.entries.length) {
+          applyFleetDataset(stored.entries, { skipSave: true, meta: stored.meta || null });
+          showFleetUploadFeedback('No se pudo conectar a Firebase. Se restauró el catálogo almacenado en este navegador.', 'warning');
+          return;
+        }
+        fleetEntries = [];
+        fleetLookup = new Map();
+        fleetDatasetMeta = null;
+        dashboardCachedEntries = [];
+        dashboardStatusFilter = 'Todos';
+        dashboardBranchFilter = 'Todas';
+        refreshOrderDatalist();
+        setOrderInputState('error', 'Sube la planilla de flota desde la pestaña Catálogo.');
+        updateFleetDatasetSummary();
+        renderFleetDashboard([]);
+        showFleetUploadFeedback('Sube la planilla de flota desde la pestaña Catálogo para habilitar la validación automática.', 'warning');
+      }
+    }
+
+    function restoreFleetDatasetFromStorage() {
+      try {
+        const raw = localStorage.getItem(FLEET_DATA_STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed) || !parsed.length) return null;
+        const metaRaw = localStorage.getItem(FLEET_DATA_META_STORAGE_KEY);
+        const meta = metaRaw ? JSON.parse(metaRaw) : null;
+        return { entries: parsed, meta };
+      } catch (error) {
+        console.warn('No se pudo restaurar el dataset de flota almacenado:', error);
+        return null;
+      }
+    }
+
+    function saveFleetDatasetToStorage(entries, meta = {}) {
+      try {
+        const sanitized = sanitizeFleetEntries(entries);
+        localStorage.setItem(FLEET_DATA_STORAGE_KEY, JSON.stringify(sanitized));
+        const payloadMeta = {
+          updatedAt: meta.updatedAt || new Date().toISOString(),
+          sourceName: meta.sourceName || meta.source || 'Importación manual',
+          fileSize: typeof meta.fileSize === 'number' ? meta.fileSize : null,
+          contentType: meta.contentType || '',
+          uploadedBy: meta.uploadedBy || ''
+        };
+        localStorage.setItem(FLEET_DATA_META_STORAGE_KEY, JSON.stringify(payloadMeta));
+        fleetDatasetMeta = payloadMeta;
+      } catch (error) {
+        console.warn('No se pudo guardar el dataset de flota:', error);
+      }
+    }
+
+    function clearFleetDatasetStorage() {
+      localStorage.removeItem(FLEET_DATA_STORAGE_KEY);
+      localStorage.removeItem(FLEET_DATA_META_STORAGE_KEY);
+    }
+
+    function applyFleetDataset(entries, options = {}) {
+      const sanitized = sanitizeFleetEntries(entries);
+      fleetEntries = sanitized;
+      fleetLookup = new Map();
+      sanitized.forEach(entry => {
+        if (entry && entry.normalizedOrder && !fleetLookup.has(entry.normalizedOrder)) {
+          fleetLookup.set(entry.normalizedOrder, entry);
+        }
+      });
+      if (!options.skipSave) {
+        saveFleetDatasetToStorage(sanitized, options.meta || {});
+      } else if (options && Object.prototype.hasOwnProperty.call(options, 'meta')) {
+        fleetDatasetMeta = options.meta || null;
+      }
+
+      if (sanitized.length) {
+        setOrderInputState('ready');
+        refreshOrderDatalist();
+        handleOrderNumberInput();
+        if (options.skipSave) {
+          showFleetUploadFeedback('Catálogo restaurado desde este navegador.', 'info');
+        }
+      } else {
+        setOrderInputState('error', 'La planilla no contiene registros válidos.');
+      }
+      updateFleetDatasetSummary();
+      renderFleetDashboard(sanitized);
+    }
+
+    function parseFleetWorkbook(arrayBuffer) {
+      const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+      const sheet = workbook.Sheets[FLEET_SHEET_NAME];
+      if (!sheet) {
+        throw new Error(`La hoja "${FLEET_SHEET_NAME}" no existe en el archivo.`);
+      }
+      const rows = XLSX.utils.sheet_to_json(sheet, { header: 1, defval: '' });
+      return buildFleetEntriesFromRows(rows);
+    }
+
+    function buildFleetEntriesFromRows(rows) {
+      if (!Array.isArray(rows) || !rows.length) {
+        throw new Error('La hoja seleccionada está vacía.');
+      }
+      const headers = rows[0] || [];
+      const maxColumns = rows.reduce((max, row) => Array.isArray(row) ? Math.max(max, row.length) : max, Array.isArray(headers) ? headers.length : 0);
+      const clampIndex = (candidate, fallbackPreference) => {
+        if (typeof candidate === 'number' && candidate >= 0 && candidate < maxColumns) {
+          return candidate;
+        }
+        const adjusted = typeof fallbackPreference === 'number' ? fallbackPreference : 0;
+        if (maxColumns === 0) return 0;
+        if (adjusted >= 0 && adjusted < maxColumns) return adjusted;
+        return Math.max(0, Math.min(maxColumns - 1, adjusted));
+      };
+
+      const orderIndex = clampIndex(findColumnIndex(headers, ORDER_KEYWORDS, FLEET_FALLBACK_INDEX.order), FLEET_FALLBACK_INDEX.order);
+      const mobileIndex = clampIndex(findColumnIndex(headers, MOBILE_KEYWORDS, FLEET_FALLBACK_INDEX.mobile), orderIndex);
+      const plateIndex = clampIndex(findColumnIndex(headers, PLATE_KEYWORDS, FLEET_FALLBACK_INDEX.plate), FLEET_FALLBACK_INDEX.plate);
+      const mileageIndex = clampIndex(findColumnIndex(headers, MILEAGE_KEYWORDS, FLEET_FALLBACK_INDEX.mileage), FLEET_FALLBACK_INDEX.mileage);
+
+      const typeIndex = findColumnIndex(headers, TYPE_KEYWORDS, -1);
+      const statusIndex = findColumnIndex(headers, STATUS_KEYWORDS, -1);
+      const makeIndex = findColumnIndex(headers, MAKE_KEYWORDS, -1);
+      const modelIndex = findColumnIndex(headers, MODEL_KEYWORDS, -1);
+      const yearIndex = findColumnIndex(headers, YEAR_KEYWORDS, -1);
+      const zoneIndex = findColumnIndex(headers, ZONE_KEYWORDS, -1);
+      const lastMileageIndex = findColumnIndex(headers, LAST_MILEAGE_KEYWORDS, -1);
+      const lastMileageDateIndex = findColumnIndex(headers, LAST_MILEAGE_DATE_KEYWORDS, -1);
+      const distanceIndex = findColumnIndex(headers, DISTANCE_TRAVELED_KEYWORDS, -1);
+      const lastMaintenanceKmIndex = findColumnIndex(headers, LAST_MAINTENANCE_KM_KEYWORDS, -1);
+      const lastMaintenanceDateIndex = findColumnIndex(headers, LAST_MAINTENANCE_DATE_KEYWORDS, -1);
+      const maintenancePlanIndex = findColumnIndex(headers, MAINTENANCE_PLAN_KEYWORDS, -1);
+      const maintenanceKmIndex = findColumnIndex(headers, MAINTENANCE_KM_KEYWORDS, -1);
+      const remainingKmIndex = findColumnIndex(headers, REMAINING_KM_KEYWORDS, -1);
+      const maintenanceStatusIndex = findColumnIndex(headers, MAINTENANCE_STATUS_KEYWORDS, -1);
+
+      const entries = [];
+
+      rows.slice(1).forEach((row) => {
+        if (!row || row.every(cell => String(cell ?? '').trim() === '')) return;
+        const rawOrder = parseStringCell(row, orderIndex);
+        const rawMobile = parseStringCell(row, mobileIndex);
+        const displayOrder = rawOrder || rawMobile;
+        const normalizedOrder = normalizeOrderKey(displayOrder || rawMobile);
+        if (!normalizedOrder) return;
+
+        const entry = {
+          orderNumber: displayOrder || normalizedOrder,
+          normalizedOrder,
+          mobileNumber: rawMobile || displayOrder || normalizedOrder,
+          plate: parseStringCell(row, plateIndex).toUpperCase(),
+          mileage: parseNumericCell(row, mileageIndex),
+          typeTransport: typeIndex >= 0 ? parseStringCell(row, typeIndex) : '',
+          status: statusIndex >= 0 ? parseStringCell(row, statusIndex) : '',
+          make: makeIndex >= 0 ? parseStringCell(row, makeIndex) : '',
+          model: modelIndex >= 0 ? parseStringCell(row, modelIndex) : '',
+          year: yearIndex >= 0 ? (() => {
+            const parsed = parseNumericCell(row, yearIndex);
+            return Number.isFinite(parsed) ? Math.round(parsed) : null;
+          })() : null,
+          zone: zoneIndex >= 0 ? parseStringCell(row, zoneIndex) : '',
+          lastMileage: lastMileageIndex >= 0 ? parseNumericCell(row, lastMileageIndex) : null,
+          lastMileageDate: lastMileageDateIndex >= 0 ? parseDateCell(row, lastMileageDateIndex) : '',
+          distanceTraveled: distanceIndex >= 0 ? parseNumericCell(row, distanceIndex) : null,
+          lastMaintenanceKm: lastMaintenanceKmIndex >= 0 ? parseNumericCell(row, lastMaintenanceKmIndex) : null,
+          lastMaintenanceDate: lastMaintenanceDateIndex >= 0 ? parseDateCell(row, lastMaintenanceDateIndex) : '',
+          maintenancePlan: maintenancePlanIndex >= 0 ? parseStringCell(row, maintenancePlanIndex) : '',
+          maintenanceKm: maintenanceKmIndex >= 0 ? parseNumericCell(row, maintenanceKmIndex) : null,
+          kmRemaining: remainingKmIndex >= 0 ? parseNumericCell(row, remainingKmIndex) : null,
+          maintenanceStatus: maintenanceStatusIndex >= 0 ? parseStringCell(row, maintenanceStatusIndex) : ''
+        };
+
+        if (entry.mileage === null || entry.mileage === undefined) {
+          const fallbackMileage = [entry.lastMileage, entry.maintenanceKm, entry.lastMaintenanceKm].find(val => typeof val === 'number' && Number.isFinite(val));
+          entry.mileage = fallbackMileage !== undefined ? fallbackMileage : null;
+        }
+
+        entries.push(entry);
+      });
+
+      if (!entries.length) {
+        throw new Error('No se encontraron registros válidos en la hoja.');
+      }
+
+      return entries;
+    }
+
+    function sanitizeFleetEntries(entries) {
+      if (!Array.isArray(entries)) return [];
+      return entries.map(normalizeFleetEntry).filter(Boolean);
+    }
+
+    function normalizeFleetEntry(entry) {
+      if (!entry) return null;
+      const normalizedOrder = normalizeOrderKey(entry.normalizedOrder || entry.orderNumber || entry.mobileNumber);
+      if (!normalizedOrder) return null;
+
+      const mileageValue = parseNumeric(entry.mileage ?? entry.lastMileage ?? entry.maintenanceKm ?? entry.lastMaintenanceKm);
+      const lastMileageValue = parseNumeric(entry.lastMileage ?? entry.ultimoKilometraje ?? entry.lastMileageValue);
+      const distanceValue = parseNumeric(entry.distanceTraveled ?? entry.kmRecorrido);
+      const lastMaintenanceKmValue = parseNumeric(entry.lastMaintenanceKm ?? entry.kmUltimaMantencion);
+      const maintenanceKmValue = parseNumeric(entry.maintenanceKm ?? entry.kmsMant);
+      const remainingKmValue = parseNumeric(entry.kmRemaining ?? entry.falta);
+      const kmRemainingValue = computeKmRemaining(
+        Number.isFinite(remainingKmValue) ? remainingKmValue : null,
+        Number.isFinite(mileageValue) ? mileageValue : null,
+        Number.isFinite(lastMileageValue) ? lastMileageValue : null,
+        Number.isFinite(maintenanceKmValue) ? maintenanceKmValue : null,
+        Number.isFinite(lastMaintenanceKmValue) ? lastMaintenanceKmValue : null
+      );
+      const rawStatus = normalizeMaintenanceStatusValue(
+        entry.maintenanceStatusRaw || entry.maintenanceStatus || entry.estadoMp || entry.estado || ''
+      );
+      const canonicalStatus = canonicalizeMaintenanceStatusText(rawStatus);
+      const resolvedStatus = canonicalStatus || inferStatusFromKm(kmRemainingValue);
+      const yearValue = parseNumeric(entry.year ?? entry.ano);
+
+      return {
+        orderNumber: entry.orderNumber || entry.mobileNumber || normalizedOrder,
+        normalizedOrder,
+        mobileNumber: entry.mobileNumber || entry.orderNumber || normalizedOrder,
+        plate: (entry.plate || entry.patente || '').toString().toUpperCase().trim(),
+        mileage: Number.isFinite(mileageValue) ? Math.round(mileageValue) : null,
+        typeTransport: normalizeTextValue(entry.typeTransport || entry.tipoTransporte || ''),
+        status: normalizeTextValue(entry.status || entry.statusGeneral || ''),
+        make: normalizeTextValue(entry.make || entry.marca || ''),
+        model: normalizeTextValue(entry.model || entry.modelo || ''),
+        year: Number.isFinite(yearValue) ? Math.round(yearValue) : null,
+        zone: normalizeZoneValue(entry.zone || entry.zonal || ''),
+        lastMileage: Number.isFinite(lastMileageValue) ? Math.round(lastMileageValue) : null,
+        lastMileageDate: formatDateValue(entry.lastMileageDate || entry.fechaUltimoKilometraje || ''),
+        distanceTraveled: Number.isFinite(distanceValue) ? distanceValue : null,
+        lastMaintenanceKm: Number.isFinite(lastMaintenanceKmValue) ? lastMaintenanceKmValue : null,
+        lastMaintenanceDate: formatDateValue(entry.lastMaintenanceDate || entry.fechaUltimaMantencion || ''),
+        maintenancePlan: normalizeTextValue(entry.maintenancePlan || entry.pautaUltimaMantencion || ''),
+        maintenanceKm: Number.isFinite(maintenanceKmValue) ? maintenanceKmValue : null,
+        kmRemaining: Number.isFinite(kmRemainingValue) ? kmRemainingValue : null,
+        maintenanceStatus: resolvedStatus || MAINTENANCE_STATUS_LABELS.unknown,
+        maintenanceStatusRaw: rawStatus
+      };
+    }
+
+    function formatNumber(value, fallback = 'N/D') {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return value.toLocaleString('es-CL');
+      }
+      return fallback;
+    }
+
+    function formatKilometers(value) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return `${Math.round(value).toLocaleString('es-CL')} km`;
+      }
+      return 'N/D';
+    }
+
+    function formatDateDisplay(value) {
+      const normalized = formatDateValue(value);
+      if (!normalized) return 'N/D';
+      const date = new Date(normalized);
+      if (!Number.isNaN(date.getTime())) {
+        try {
+          return date.toLocaleDateString('es-CL');
+        } catch (error) {
+          console.warn('No se pudo formatear la fecha para el dashboard:', error);
+        }
+      }
+      return normalized;
+    }
+
+    function formatDateTimeDisplay(value) {
+      if (!value) return 'fecha desconocida';
+      const normalized = formatDateValue(value);
+      const date = new Date(normalized);
+      if (!Number.isNaN(date.getTime())) {
+        try {
+          return date.toLocaleString('es-CL', { dateStyle: 'medium', timeStyle: 'short' });
+        } catch (error) {
+          console.warn('No se pudo formatear fecha y hora:', error);
+        }
+      }
+      return normalized;
+    }
+
+    function getStatusColor(status) {
+      const normalized = (status || '').toString().toLowerCase();
+      if (normalized.includes('venc') || normalized.includes('crit') || normalized.includes('rojo')) {
+        return 'rgba(220, 38, 38, 0.7)';
+      }
+      if (normalized.includes('pend') || normalized.includes('prog') || normalized.includes('amar') || normalized.includes('prox')) {
+        return 'rgba(251, 191, 36, 0.7)';
+      }
+      if (normalized.includes('ok') || normalized.includes('vigente') || normalized.includes('verde') || normalized.includes('complet')) {
+        return 'rgba(5, 150, 105, 0.7)';
+      }
+      return 'rgba(59, 130, 246, 0.7)';
+    }
+
+    function getStatusChipClasses(status, isActive) {
+      const base = 'px-3 py-1 rounded-full text-xs font-medium transition';
+      if (isActive) {
+        return `${base} bg-primary text-white border border-primary shadow-sm`;
+      }
+      return `${base} border border-gray-300 text-gray-600 bg-white hover:border-primary hover:text-primary`;
+    }
+
+    function showFleetUploadFeedback(message, type = 'info') {
+      const container = document.getElementById('fleetUploadFeedback');
+      if (!container) return;
+      const classes = {
+        success: 'text-green-600',
+        error: 'text-red-600',
+        warning: 'text-amber-600',
+        info: 'text-gray-600'
+      };
+      container.textContent = message;
+      container.className = `mt-2 text-sm font-medium ${classes[type] || classes.info}`;
+    }
+
+    function updateFleetDatasetSummary() {
+      const container = document.getElementById('fleetDatasetStats');
+      if (!container) return;
+      if (!fleetEntries.length) {
+        container.innerHTML = `
+          <div class="p-4 border-2 border-dashed border-gray-300 bg-gray-50 rounded-lg text-sm text-gray-500">
+            Aún no cargas la planilla de flota. Usa el botón "Actualizar catálogo" para importar el Excel "${FLEET_SHEET_NAME}".
+          </div>
+        `;
+        return;
+      }
+
+      const total = fleetEntries.length;
+      let dueNow = 0;
+      let dueSoon = 0;
+      fleetEntries.forEach((entry) => {
+        const kmRemaining = getKmRemainingValue(entry);
+        if (Number.isFinite(kmRemaining)) {
+          if (kmRemaining <= 0) {
+            dueNow += 1;
+            return;
+          }
+          if (kmRemaining <= DEFAULT_KM_ALERT_THRESHOLD) {
+            dueSoon += 1;
+            return;
+          }
+        }
+        const status = getMaintenanceStatus(entry);
+        if (status === MAINTENANCE_STATUS_LABELS.overdue) {
+          dueNow += 1;
+        } else if (status === MAINTENANCE_STATUS_LABELS.upcoming) {
+          dueSoon += 1;
+        }
+      });
+      const updatedText = fleetDatasetMeta?.updatedAt ? formatDateTimeDisplay(fleetDatasetMeta.updatedAt) : 'fecha desconocida';
+      const source = fleetDatasetMeta?.sourceName || 'Importación manual';
+
+      container.innerHTML = `
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <div class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+            <p class="text-xs uppercase text-gray-500 tracking-wide">Vehículos cargados</p>
+            <p class="text-2xl font-semibold text-gray-800 mt-1">${formatNumber(total, '0')}</p>
+          </div>
+          <div class="p-4 bg-red-50 border border-red-200 rounded-lg shadow-sm">
+            <p class="text-xs uppercase text-red-600 tracking-wide">Mantención vencida</p>
+            <p class="text-2xl font-semibold text-red-600 mt-1">${formatNumber(dueNow, '0')}</p>
+          </div>
+          <div class="p-4 bg-amber-50 border border-amber-200 rounded-lg shadow-sm">
+            <p class="text-xs uppercase text-amber-600 tracking-wide">Próximas a vencer (&le; ${DEFAULT_KM_ALERT_THRESHOLD.toLocaleString('es-CL')} km)</p>
+            <p class="text-2xl font-semibold text-amber-600 mt-1">${formatNumber(dueSoon, '0')}</p>
+          </div>
+          <div class="p-4 bg-emerald-50 border border-emerald-200 rounded-lg shadow-sm">
+            <p class="text-xs uppercase text-emerald-600 tracking-wide">Última actualización</p>
+            <p class="text-sm font-semibold text-emerald-700 mt-1 leading-tight">${updatedText}</p>
+            <p class="text-xs text-emerald-600 mt-1 truncate">${source}</p>
+          </div>
+        </div>
+      `;
+    }
+
+    function renderDashboardDetail(entries, statusFilter = 'Todos') {
+      const body = document.getElementById('dashboardDetailBody');
+      if (!body) return;
+      if (!Array.isArray(entries) || !entries.length) {
+        const message = dashboardCachedEntries.length
+          ? 'No hay vehículos que coincidan con el filtro seleccionado.'
+          : 'Carga la planilla de flota para ver el detalle.';
+        body.innerHTML = `<tr><td colspan="5" class="px-2 py-4 text-center text-sm text-gray-500">${message}</td></tr>`;
+        return;
+      }
+
+      const filtered = entries.filter(entry => {
+        const status = getMaintenanceStatus(entry);
+        if (statusFilter === 'Todos') return true;
+        return status.toLowerCase() === statusFilter.toLowerCase();
+      });
+
+      const sorted = filtered
+        .map(entry => {
+          const kmRemaining = getKmRemainingValue(entry);
+          return {
+            ...entry,
+            kmRemainingValue: Number.isFinite(kmRemaining) ? kmRemaining : null
+          };
+        })
+        .sort((a, b) => {
+          const aValue = a.kmRemainingValue !== null ? a.kmRemainingValue : Number.POSITIVE_INFINITY;
+          const bValue = b.kmRemainingValue !== null ? b.kmRemainingValue : Number.POSITIVE_INFINITY;
+          return aValue - bValue;
+        })
+        .slice(0, 12);
+
+      if (!sorted.length) {
+        body.innerHTML = '<tr><td colspan="5" class="px-2 py-4 text-center text-sm text-gray-500">No hay vehículos en este filtro.</td></tr>';
+        return;
+      }
+
+      body.innerHTML = sorted.map(entry => {
+        const kmClass = entry.kmRemainingValue !== null && entry.kmRemainingValue <= 0 ? 'text-red-600 font-semibold' : 'text-gray-700';
+        const statusText = getMaintenanceStatus(entry);
+        return `
+          <tr class="border-b last:border-0">
+            <td class="px-2 py-2 font-semibold text-gray-800">${entry.orderNumber}</td>
+            <td class="px-2 py-2 text-gray-600">${entry.plate || 'N/D'}</td>
+            <td class="px-2 py-2 ${kmClass}">${formatKilometers(entry.kmRemainingValue)}</td>
+            <td class="px-2 py-2 text-gray-600">${statusText}</td>
+            <td class="px-2 py-2 text-gray-500">${formatDateDisplay(entry.lastMaintenanceDate)}</td>
+          </tr>
+        `;
+      }).join('');
+    }
+
+    function renderFleetDashboard(entries = fleetEntries) {
+      const emptyState = document.getElementById('dashboardEmptyState');
+      const content = document.getElementById('dashboardContent');
+      const summary = document.getElementById('dashboardSummary');
+      const updatedAtEl = document.getElementById('dashboardUpdatedAt');
+      const statusFilters = document.getElementById('dashboardStatusFilters');
+      const branchFilters = document.getElementById('dashboardBranchFilters');
+
+      dashboardCachedEntries = Array.isArray(entries) ? entries : [];
+
+      if (!emptyState || !content) return;
+      if (!dashboardCachedEntries.length) {
+        dashboardStatusFilter = 'Todos';
+        dashboardBranchFilter = 'Todas';
+        emptyState.classList.remove('hidden');
+        content.classList.add('hidden');
+        if (updatedAtEl) updatedAtEl.textContent = '';
+        if (statusFilters) statusFilters.innerHTML = '';
+        if (branchFilters) branchFilters.innerHTML = '';
+        if (maintenanceStatusChart) {
+          maintenanceStatusChart.destroy();
+          maintenanceStatusChart = null;
+        }
+        renderDashboardDetail([], 'Todos');
+        return;
+      }
+
+      emptyState.classList.add('hidden');
+      content.classList.remove('hidden');
+
+      if (updatedAtEl) {
+        updatedAtEl.textContent = fleetDatasetMeta?.updatedAt ? `Actualizado: ${formatDateTimeDisplay(fleetDatasetMeta.updatedAt)}` : '';
+      }
+
+      const zoneCounts = dashboardCachedEntries.reduce((acc, entry) => {
+        const zoneLabel = getZoneLabel(entry);
+        acc[zoneLabel] = (acc[zoneLabel] || 0) + 1;
+        return acc;
+      }, {});
+      const sortedZones = Object.keys(zoneCounts).sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+      if (dashboardBranchFilter !== 'Todas' && !zoneCounts[dashboardBranchFilter]) {
+        dashboardBranchFilter = 'Todas';
+      }
+
+      if (branchFilters) {
+        branchFilters.innerHTML = '';
+        const buildButton = (label, value, count) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = getStatusChipClasses(value, dashboardBranchFilter === value);
+          button.textContent = `${label} (${formatNumber(count, '0')})`;
+          button.addEventListener('click', () => {
+            dashboardBranchFilter = value;
+            dashboardStatusFilter = 'Todos';
+            renderFleetDashboard(dashboardCachedEntries);
+          });
+          branchFilters.appendChild(button);
+        };
+        buildButton('Todas', 'Todas', dashboardCachedEntries.length);
+        sortedZones.forEach(zone => buildButton(zone, zone, zoneCounts[zone]));
+      }
+
+      const branchFilteredEntries = dashboardBranchFilter === 'Todas'
+        ? dashboardCachedEntries
+        : dashboardCachedEntries.filter(entry => getZoneLabel(entry) === dashboardBranchFilter);
+
+      let dueNow = 0;
+      let dueSoon = 0;
+      branchFilteredEntries.forEach((entry) => {
+        const kmRemaining = getKmRemainingValue(entry);
+        if (Number.isFinite(kmRemaining)) {
+          if (kmRemaining <= 0) {
+            dueNow += 1;
+          } else if (kmRemaining <= DEFAULT_KM_ALERT_THRESHOLD) {
+            dueSoon += 1;
+          }
+        } else {
+          const status = getMaintenanceStatus(entry);
+          if (status === MAINTENANCE_STATUS_LABELS.overdue) {
+            dueNow += 1;
+          } else if (status === MAINTENANCE_STATUS_LABELS.upcoming) {
+            dueSoon += 1;
+          }
+        }
+      });
+      const averageMileageValues = branchFilteredEntries
+        .map(entry => {
+          if (typeof entry.lastMileage === 'number' && Number.isFinite(entry.lastMileage)) return entry.lastMileage;
+          if (typeof entry.mileage === 'number' && Number.isFinite(entry.mileage)) return entry.mileage;
+          return null;
+        })
+        .filter(value => value !== null);
+      const averageMileage = averageMileageValues.length
+        ? Math.round(averageMileageValues.reduce((sum, value) => sum + value, 0) / averageMileageValues.length)
+        : null;
+
+      if (summary) {
+        summary.innerHTML = `
+          <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div class="p-4 bg-primary/10 border border-primary/30 rounded-lg">
+              <p class="text-xs uppercase text-primary tracking-wide font-semibold">Vehículos registrados</p>
+              <p class="text-3xl font-bold text-primary mt-2">${formatNumber(branchFilteredEntries.length, '0')}</p>
+            </div>
+            <div class="p-4 bg-red-50 border border-red-200 rounded-lg">
+              <p class="text-xs uppercase text-red-600 tracking-wide font-semibold">Mantención vencida</p>
+              <p class="text-3xl font-bold text-red-600 mt-2">${formatNumber(dueNow, '0')}</p>
+            </div>
+            <div class="p-4 bg-amber-50 border border-amber-200 rounded-lg">
+              <p class="text-xs uppercase text-amber-600 tracking-wide font-semibold">Próximas (&le; ${DEFAULT_KM_ALERT_THRESHOLD.toLocaleString('es-CL')} km)</p>
+              <p class="text-3xl font-bold text-amber-600 mt-2">${formatNumber(dueSoon, '0')}</p>
+            </div>
+            <div class="p-4 bg-emerald-50 border border-emerald-200 rounded-lg">
+              <p class="text-xs uppercase text-emerald-600 tracking-wide font-semibold">Kilometraje promedio</p>
+              <p class="text-3xl font-bold text-emerald-600 mt-2">${averageMileage !== null ? formatNumber(averageMileage, '0') + ' km' : 'N/D'}</p>
+            </div>
+          </div>
+        `;
+      }
+
+      const statusCounts = branchFilteredEntries.reduce((acc, entry) => {
+        const status = getMaintenanceStatus(entry);
+        acc[status] = (acc[status] || 0) + 1;
+        return acc;
+      }, {});
+      const statuses = Object.keys(statusCounts).sort((a, b) => {
+        const priorityA = MAINTENANCE_STATUS_PRIORITY.has(a) ? MAINTENANCE_STATUS_PRIORITY.get(a) : 99;
+        const priorityB = MAINTENANCE_STATUS_PRIORITY.has(b) ? MAINTENANCE_STATUS_PRIORITY.get(b) : 99;
+        if (priorityA !== priorityB) {
+          return priorityA - priorityB;
+        }
+        return a.localeCompare(b, 'es', { sensitivity: 'base' });
+      });
+      if (dashboardStatusFilter !== 'Todos' && !statuses.some(status => status.toLowerCase() === dashboardStatusFilter.toLowerCase())) {
+        dashboardStatusFilter = 'Todos';
+      }
+
+      if (statusFilters) {
+        statusFilters.innerHTML = '';
+        const buildStatusButton = (label, value, count) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = getStatusChipClasses(value, dashboardStatusFilter === value);
+          button.textContent = `${label} (${formatNumber(count, '0')})`;
+          button.addEventListener('click', () => {
+            dashboardStatusFilter = value;
+            renderFleetDashboard(dashboardCachedEntries);
+          });
+          statusFilters.appendChild(button);
+        };
+        buildStatusButton('Todos', 'Todos', branchFilteredEntries.length);
+        statuses.forEach(status => buildStatusButton(status, status, statusCounts[status]));
+      }
+
+      const chartCanvas = document.getElementById('maintenanceStatusChart');
+      if (chartCanvas && typeof window.Chart !== 'undefined') {
+        if (maintenanceStatusChart) {
+          maintenanceStatusChart.destroy();
+          maintenanceStatusChart = null;
+        }
+        const ctx = chartCanvas.getContext('2d');
+        maintenanceStatusChart = new window.Chart(ctx, {
+          type: 'pie',
+          data: {
+            labels: statuses,
+            datasets: [{
+              label: 'Vehículos',
+              data: statuses.map(status => statusCounts[status] || 0),
+              backgroundColor: statuses.map(getStatusColor),
+              borderWidth: 1,
+              borderColor: '#ffffff'
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { position: 'bottom' }
+            }
+          }
+        });
+      }
+
+      renderDashboardDetail(branchFilteredEntries, dashboardStatusFilter);
+    }
+
+    async function uploadFleetWorkbookToCloud(file, meta = {}) {
+      if (!storage) {
+        throw new Error('Firebase Storage no está inicializado.');
+      }
+      const catalogRef = storageRef(storage, FLEET_STORAGE_PATH);
+      await uploadBytes(catalogRef, file, { contentType: file.type || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+      if (db) {
+        try {
+          const metadataRef = doc(db, 'artifacts', appId, 'meta', FLEET_METADATA_DOC_ID);
+          const nowIso = new Date().toISOString();
+          await setDoc(metadataRef, {
+            sourceName: meta.sourceName || file.name || 'Catálogo de flota',
+            fileSize: file.size || null,
+            contentType: file.type || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            updatedAt: serverTimestamp(),
+            updatedAtClient: nowIso,
+            uploadedBy: currentUserId || null
+          }, { merge: true });
+          return {
+            sourceName: meta.sourceName || file.name || 'Catálogo de flota',
+            fileSize: file.size || null,
+            contentType: file.type || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            updatedAt: nowIso,
+            uploadedBy: currentUserId || null
+          };
+        } catch (error) {
+          console.warn('No se pudo registrar la metadata del catálogo en Firestore:', error);
+        }
+      }
+      return {
+        sourceName: meta.sourceName || file.name || 'Catálogo de flota',
+        fileSize: file.size || null,
+        contentType: file.type || '',
+        updatedAt: new Date().toISOString(),
+        uploadedBy: currentUserId || null
+      };
+    }
+
+    async function handleFleetFileSelection(event) {
+      const input = event.target;
+      const file = input?.files?.[0];
+      if (!file) return;
+
+      showFleetUploadFeedback(`Procesando "${file.name}"...`, 'info');
+      showAdminFeedback(`Procesando archivo "${file.name}"...`, 'info');
+
+      try {
+        const extension = file.name.split('.').pop().toLowerCase();
+        if (!['xlsx', 'xls', 'xlsm'].includes(extension)) {
+          throw new Error('Selecciona un archivo Excel (.xlsx o .xls).');
+        }
+
+        const arrayBuffer = await file.arrayBuffer();
+        const entries = parseFleetWorkbook(arrayBuffer);
+        const uploadMeta = await uploadFleetWorkbookToCloud(file, { sourceName: file.name });
+        let appliedEntries = entries;
+        let appliedMeta = uploadMeta;
+        try {
+          const cloudResult = await fetchFleetDatasetFromCloud();
+          if (cloudResult && Array.isArray(cloudResult.entries) && cloudResult.entries.length) {
+            appliedEntries = cloudResult.entries;
+            appliedMeta = cloudResult.meta || uploadMeta;
+          }
+        } catch (syncError) {
+          console.warn('No se pudo refrescar el catálogo desde Firebase tras la carga:', syncError);
+        }
+        applyFleetDataset(appliedEntries, { meta: appliedMeta });
+        showAdminFeedback(`Catálogo sincronizado en Firebase con ${appliedEntries.length} vehículos desde "${file.name}".`, 'success');
+        showFleetUploadFeedback('Catálogo de flota actualizado en Firebase correctamente.', 'success');
+        displayAppMessage('Planilla de flota cargada y sincronizada en Firebase.', 'success');
+      } catch (error) {
+        console.error('Error al procesar el archivo de flota:', error);
+        const message = error?.message || 'No se pudo procesar el archivo de flota.';
+        showAdminFeedback(message, 'error');
+        showFleetUploadFeedback(message, 'error');
+        displayAppMessage('No se pudo procesar el archivo de flota.', 'error');
+      } finally {
+        if (input) {
+          input.value = '';
+        }
+      }
+    }
+
+    function requestFleetUpload() {
+      document.getElementById('fleetFileInput')?.click();
+    }
+
+    function handleClearFleetDataset() {
+      if (!window.confirm('¿Eliminar el catálogo de flota almacenado en este navegador?')) {
+        return;
+      }
+      clearFleetDatasetStorage();
+      fleetEntries = [];
+      fleetLookup = new Map();
+      fleetDatasetMeta = null;
+      dashboardCachedEntries = [];
+      dashboardStatusFilter = 'Todos';
+      dashboardBranchFilter = 'Todas';
+      refreshOrderDatalist();
+      setOrderInputState('error', 'Sube la planilla de flota desde la pestaña Catálogo.');
+      updateFleetDatasetSummary();
+      renderFleetDashboard([]);
+      resetOrderAutofill();
+      showAdminFeedback('Catálogo local eliminado. Carga una nueva planilla para continuar.', 'info');
+      showFleetUploadFeedback('Catálogo eliminado de este navegador.', 'info');
+      displayAppMessage('Catálogo de flota eliminado correctamente.', 'info');
+    }
+
+    window.requestFleetUpload = requestFleetUpload;
+    window.clearFleetDataset = handleClearFleetDataset;
+
+    function compareOrderNumbers(a, b) {
+      const valueA = normalizeOrderKey(a);
+      const valueB = normalizeOrderKey(b);
+      if (valueA === valueB) return 0;
+      const numericA = parseInt(valueA.replace(/[^0-9]/g, ''), 10);
+      const numericB = parseInt(valueB.replace(/[^0-9]/g, ''), 10);
+      if (Number.isFinite(numericA) && Number.isFinite(numericB) && numericA !== numericB) {
+        return numericA - numericB;
+      }
+      return valueA.localeCompare(valueB, 'es', { numeric: true, sensitivity: 'base' });
+    }
 
     // --- TUS CREDENCIALES DE FIREBASE ---
     const firebaseConfig = {
@@ -113,6 +1464,7 @@
         app = initializeApp(firebaseConfig);
         db = getFirestore(app);
         auth = getAuth(app);
+        storage = getStorage(app);
 
         onAuthStateChanged(auth, user => {
           if (user) {
@@ -318,10 +1670,15 @@
       const recordDetails = formatRecordForPrompt(record);
       const systemPrompt = "Actúa como ingeniero de mantenimiento de flotas y experto en neumáticos. Analiza el informe de surcos. Indica neumáticos críticos (<3mm) y sugiere un plan de acción conciso y priorizado (rotación, reemplazo, alineación, presión). Usa fuentes web si es útil y lista las citas.";
       const userQuery = `Análisis de la Orden N° ${record.orderNumber} con ${record.mileage} km:\n\n${recordDetails}`;
+      if (!apiKey) {
+        console.error('No se ha configurado la clave de API de Gemini.');
+        return displayAppMessage('Configura la clave de Gemini antes de usar el análisis con IA.', 'error');
+      }
+
       const payload = {
-        contents: [{ parts: [{ text: userQuery }] }],
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        tools: [{ "google_search": {} }]
+        contents: [{ role: 'user', parts: [{ text: userQuery }] }],
+        systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
+        tools: [{ google_search: {} }]
       };
 
       try {
@@ -330,13 +1687,15 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
         });
-        if (!res.ok) throw new Error(`Gemini API request failed with status ${res.status}`);
-
         const result = await res.json();
+        if (!res.ok) {
+          const apiError = result?.error?.message;
+          throw new Error(apiError ? `Gemini API error: ${apiError}` : `Gemini API request failed with status ${res.status}`);
+        }
         const candidate = result?.candidates?.[0];
         const text = candidate?.content?.parts?.[0]?.text || 'No se pudo generar un análisis.';
         const sources = (candidate?.groundingMetadata?.groundingAttributions || []).map(a => ({ uri: a?.web?.uri, title: a?.web?.title })).filter(s => s.uri && s.title);
-        
+
         displayAppMessage(`✅ Análisis de Orden N° ${record.orderNumber} generado.`, 'success');
         console.log(`--- Análisis Gemini Orden N° ${record.orderNumber} ---`);
         console.log(text);
@@ -348,7 +1707,8 @@
 
       } catch (e) {
         console.error("Error en el análisis con Gemini:", e);
-        displayAppMessage('Error al conectar con la IA.', 'error');
+        const friendlyMessage = e?.message?.startsWith('Gemini API') ? e.message : 'Error al conectar con la IA.';
+        displayAppMessage(friendlyMessage, 'error');
       }
     }
 
@@ -560,7 +1920,7 @@
             }
         });
         
-        const latestRecords = Array.from(latestRecordsMap.values()).sort((a, b) => a.orderNumber - b.orderNumber);
+        const latestRecords = Array.from(latestRecordsMap.values()).sort((a, b) => compareOrderNumbers(a.orderNumber, b.orderNumber));
 
         const { jsPDF } = window.jspdf;
         const doc = new jsPDF();
@@ -725,7 +2085,7 @@
     }
 
     window.switchTab = function(tabName) {
-      ['guide', 'register', 'records'].forEach(tab => {
+      ['guide', 'register', 'records', 'admin'].forEach(tab => {
         document.getElementById(`tab-button-${tab}`)?.classList.toggle('active', tab === tabName);
         document.getElementById(`tab-content-${tab}`)?.classList.toggle('hidden', tab !== tabName);
       });
@@ -735,6 +2095,9 @@
         const filter = document.getElementById('branchFilter');
         if (filter) filter.value = 'all';
         applyFiltersAndDisplay();
+      }
+      if (tabName === 'admin') {
+        renderCatalogLists();
       }
     }
 
@@ -749,6 +2112,8 @@
       if (reviewBtn) reviewBtn.disabled = true;
       const dateEl = document.getElementById('date');
       if (dateEl) dateEl.value = new Date().toISOString().slice(0, 10);
+      resetOrderAutofill();
+      refreshCatalogSelects();
     }
 
     window.generateTireInputs = function() {
@@ -756,6 +2121,7 @@
       const container = document.getElementById('tireInputsContainer');
       container.innerHTML = '';
       const positions = TIRES_STRUCTURE[vehicleType] || [];
+      const modelOptions = getMakeModelOptionsMarkup();
 
       positions.forEach((position, index) => {
         const positionDesc = getPositionDescription(position);
@@ -767,7 +2133,7 @@
               <label class="block text-xs font-medium text-gray-700 mb-1" for="tireMakeModel-${index}">Marca y Modelo (Específico)</label>
               <select id="tireMakeModel-${index}" name="tireMakeModel_${position}" class="form-control text-sm">
                 <option value="" selected>Usar marca general del formulario</option>
-                ${PREDEFINED_MODELS.map(m => `<option value="${m}">${m}</option>`).join('')}
+                ${modelOptions}
               </select>
             </div>
             <div class="grid grid-cols-3 gap-2 mb-4">
@@ -813,9 +2179,35 @@
             return;
         }
 
+        const orderInput = document.getElementById('orderNumber');
+        if (orderInput && !orderInput.checkValidity()) {
+            displayReview([{type: 'error', text: orderInput.validationMessage || 'Número de orden inválido.'}]);
+            finishReview(reviewBtn);
+            return;
+        }
+
+        const normalizedOrder = normalizeOrderKey(generalData.orderNumber);
+        if (!normalizedOrder) {
+            displayReview([{type: 'error', text: 'Ingresa un número de orden válido.'}]);
+            finishReview(reviewBtn);
+            return;
+        }
+
+        const matchedOrder = fleetLookup.get(normalizedOrder);
+        const orderDisplay = matchedOrder?.orderNumber || generalData.orderNumber.trim();
+        const vehiclePlate = generalData.vehiclePlate || matchedOrder?.plate || '';
+
+        const mileageValue = parseInt(generalData.mileage, 10);
+        if (!Number.isFinite(mileageValue)) {
+            displayReview([{type: 'error', text: 'El kilometraje debe ser un número válido.'}]);
+            finishReview(reviewBtn);
+            return;
+        }
+
         const data = {
-            orderNumber: parseInt(generalData.orderNumber),
-            mileage: parseInt(generalData.mileage),
+            orderNumber: orderDisplay,
+            orderNumberNormalized: normalizedOrder,
+            mileage: mileageValue,
             date: generalData.date,
             tireSize: generalData.tireSize,
             vehicleType: generalData.vehicleType,
@@ -823,6 +2215,7 @@
             generalComments: generalData.generalComments || '',
             technicianId: currentUserId,
             branchName: generalData.branchName,
+            vehiclePlate,
             tires: [],
             photoFiles: []
         };
@@ -1340,13 +2733,24 @@
     
     // === INICIO DE LA APP ===
     window.onload = function() {
-      initializeAppCore().then(() => {
-        const makeModelSelect = document.getElementById('makeModel');
-        const tireSizeSelect = document.getElementById('tireSize');
+      loadCatalogFromStorage();
+      renderCatalogLists();
+      attachOrderNumberHandlers();
+
+      const fleetFileInput = document.getElementById('fleetFileInput');
+      if (fleetFileInput) {
+        fleetFileInput.addEventListener('change', handleFleetFileSelection);
+      }
+
+      initializeAppCore().then(async () => {
         const branchSelect = document.getElementById('branchName');
-        PREDEFINED_MODELS.forEach(m => makeModelSelect.insertAdjacentHTML('beforeend', `<option value="${m}">${m}</option>`));
-        PREDEFINED_SIZES.forEach(s => tireSizeSelect.insertAdjacentHTML('beforeend', `<option value="${s}">${s}</option>`));
-        BRANCHES.forEach(b => branchSelect.insertAdjacentHTML('beforeend', `<option value="${b}">${b}</option>`));
+        if (branchSelect) {
+          branchSelect.innerHTML = '<option value="" disabled selected>Selecciona una sucursal...</option>' + BRANCHES.map(branch => `<option value="${branch}">${branch}</option>`).join('');
+        }
+
+        refreshCatalogSelects();
+
+        await loadFleetDataset();
 
         const exportMenuButton = document.getElementById('exportMenuButton');
         const exportMenu = document.getElementById('exportMenu');
@@ -1410,6 +2814,8 @@
             <button id="tab-button-guide" onclick="switchTab('guide')" type="button" class="tab-button">Guía Rápida</button>
             <button id="tab-button-register" onclick="switchTab('register')" type="button" class="tab-button">Registrar</button>
             <button id="tab-button-records" onclick="switchTab('records')" type="button" class="tab-button">Historial</button>
+            <button id="tab-button-admin" onclick="switchTab('admin')" type="button" class="tab-button hidden" data-creator-tab>Catálogo</button>
+            <!-- Para habilitar el acceso privado, elimina la clase "hidden" del botón Catálogo desde las herramientas del navegador. -->
           </div>
         </div>
       </nav>
@@ -1449,7 +2855,13 @@
               </div>
               <div>
                 <label for="orderNumber" class="block text-sm font-medium text-gray-700 mb-1">Número de Orden (Vehículo)</label>
-                <input type="number" id="orderNumber" name="orderNumber" class="form-control" placeholder="Ej: 12345" required />
+                <input type="text" id="orderNumber" name="orderNumber" class="form-control" placeholder="Cargando catálogo..." inputmode="numeric" autocomplete="off" list="orderNumberOptions" required />
+                <datalist id="orderNumberOptions"></datalist>
+                <p id="orderNumberFeedback" class="mt-1 text-xs text-gray-500">Número de orden del vehículo.</p>
+              </div>
+              <div>
+                <label for="vehiclePlate" class="block text-sm font-medium text-gray-700 mb-1">Patente Asociada</label>
+                <input type="text" id="vehiclePlate" name="vehiclePlate" class="form-control readonly-input" placeholder="Se completará automáticamente" readonly tabindex="-1" />
               </div>
               <div>
                 <label for="mileage" class="block text-sm font-medium text-gray-700 mb-1">Kilometraje</label>
@@ -1502,6 +2914,60 @@
             </button>
           </div>
         </form>
+      </div>
+
+      <div id="tab-content-admin" class="hidden">
+        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+          <h2 class="text-xl font-bold text-gray-800 mb-2">Catálogo privado de neumáticos</h2>
+          <p class="text-sm text-gray-600">Esta sección está oculta para el resto del equipo. Utilízala para registrar nuevas marcas/modelos y medidas que luego aparecerán en el formulario principal.</p>
+          <div id="adminFeedback" class="mt-4 text-sm text-gray-500"></div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+            <form id="catalogModelForm" onsubmit="handleAdminAddModel(event)" class="space-y-3">
+              <h3 class="text-lg font-semibold text-gray-700">Registrar marca/modelo</h3>
+              <p class="text-xs text-gray-500">Agrega combinaciones para reutilizarlas en la medición general o por neumático.</p>
+              <input type="text" id="newModel" class="form-control" placeholder="Ej: Continental Conti Coach HA3" required />
+              <button type="submit" class="px-4 py-2 bg-primary text-white text-sm font-semibold rounded-lg hover:bg-secondary transition">Guardar modelo</button>
+            </form>
+            <form id="catalogSizeForm" onsubmit="handleAdminAddSize(event)" class="space-y-3">
+              <h3 class="text-lg font-semibold text-gray-700">Registrar medida</h3>
+              <p class="text-xs text-gray-500">Agrega nuevas medidas (usa formato 295/80R22.5).</p>
+              <input type="text" id="newSize" class="form-control" placeholder="Ej: 275/70R22.5" required />
+              <button type="submit" class="px-4 py-2 bg-secondary text-white text-sm font-semibold rounded-lg hover:bg-primary transition">Guardar medida</button>
+            </form>
+          </div>
+          <div class="mt-8">
+            <h3 class="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">Modelos personalizados</h3>
+            <div id="customModelList" class="flex flex-wrap gap-2"></div>
+          </div>
+          <div class="mt-6">
+            <h3 class="text-sm font-semibold text-gray-600 uppercase tracking-wide mb-3">Medidas personalizadas</h3>
+            <div id="customSizeList" class="flex flex-wrap gap-2"></div>
+          </div>
+          <p class="mt-6 text-xs text-gray-400">Los datos se almacenan localmente en este navegador. Exporta la lista si deseas respaldarla.</p>
+          <div class="mt-10 border-t border-dashed border-gray-200 pt-6">
+            <div class="flex items-center justify-between flex-wrap gap-2">
+              <h3 class="text-lg font-semibold text-gray-700">Catálogo de flota (Excel)</h3>
+              <span class="text-xs font-medium text-gray-500">Solo visible para el creador</span>
+            </div>
+            <p class="text-sm text-gray-600 mt-2">
+              Importa el archivo actualizado con las columnas <strong>Tipo de Transporte, Status, N° de Movil, Patente, Marca, Modelo, Año, Zonal, Último kilometraje, Fecha Último kilometraje, Km. Recorrido, Km. última Mantención, Fecha última Mantención, Pauta última Mantención, Kms de Mant., Falta y Estado MP</strong>.
+              El sistema validará la hoja <em>"Flota Verschae"</em> y actualizará los datos disponibles en el formulario y en el dashboard.
+            </p>
+            <div class="mt-4 flex flex-wrap items-center gap-3">
+              <button type="button" onclick="requestFleetUpload()" class="px-4 py-2 bg-primary text-white text-sm font-semibold rounded-lg shadow-sm hover:bg-secondary transition">
+                Actualizar catálogo
+              </button>
+              <button type="button" onclick="clearFleetDataset()" class="px-4 py-2 bg-red-100 text-red-600 text-sm font-semibold rounded-lg shadow-sm hover:bg-red-200 transition">
+                Eliminar catálogo local
+              </button>
+            </div>
+            <input type="file" id="fleetFileInput" accept=".xlsx,.xls,.xlsm" class="hidden" />
+            <p id="fleetUploadFeedback" class="mt-2 text-sm text-gray-500">
+              Aún no se ha cargado un catálogo. Usa "Actualizar catálogo" para seleccionar el Excel de flota.
+            </p>
+            <div id="fleetDatasetStats" class="mt-6"></div>
+          </div>
+        </div>
       </div>
 
       <div id="tab-content-records" class="hidden">
@@ -1589,6 +3055,60 @@
             </table>
         </div>
       </div>
+
+      <section id="dashboardSection" class="mt-16">
+        <div class="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+          <div class="flex flex-wrap items-start justify-between gap-4">
+            <h2 class="text-2xl font-bold text-gray-800">Dashboard de Mantenciones Preventivas</h2>
+            <span id="dashboardUpdatedAt" class="text-sm text-gray-500"></span>
+          </div>
+          <p class="text-sm text-gray-600 mt-2">Los indicadores se actualizan con el último Excel cargado desde el catálogo privado.</p>
+          <div id="dashboardEmptyState" class="mt-6 p-6 bg-gray-50 border border-dashed border-gray-300 rounded-lg text-sm text-gray-500">
+            Aún no hay datos cargados. Importa la planilla de flota para visualizar el estado de las mantenciones.
+          </div>
+          <div id="dashboardContent" class="mt-6 hidden">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+              <div>
+                <p class="text-xs uppercase text-gray-500 tracking-wide font-semibold">Sucursales</p>
+                <div id="dashboardBranchFilters" class="flex flex-wrap gap-2 mt-2"></div>
+              </div>
+              <div>
+                <p class="text-xs uppercase text-gray-500 tracking-wide font-semibold">Estados MP</p>
+                <div id="dashboardStatusFilters" class="flex flex-wrap gap-2 mt-2"></div>
+              </div>
+            </div>
+            <div id="dashboardSummary"></div>
+            <div class="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-4">
+                <div class="flex items-center justify-between gap-4">
+                  <h3 class="text-lg font-semibold text-gray-700">Estado de mantención</h3>
+                </div>
+                <div class="mt-4 h-64">
+                  <canvas id="maintenanceStatusChart"></canvas>
+                </div>
+              </div>
+              <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-4">
+                <h3 class="text-lg font-semibold text-gray-700">Prioridad de intervención</h3>
+                <p class="text-xs text-gray-500 mb-4">Ordenado por kilómetros restantes para la próxima mantención preventiva.</p>
+                <div class="overflow-y-auto max-h-72">
+                  <table class="min-w-full text-sm">
+                    <thead>
+                      <tr class="text-left text-xs uppercase tracking-wide text-gray-500 border-b">
+                        <th class="px-2 py-2">Orden</th>
+                        <th class="px-2 py-2">Patente</th>
+                        <th class="px-2 py-2">Falta</th>
+                        <th class="px-2 py-2">Estado</th>
+                        <th class="px-2 py-2">Última Mantención</th>
+                      </tr>
+                    </thead>
+                    <tbody id="dashboardDetailBody"></tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
     </main>
   </div>


### PR DESCRIPTION
## Summary
- canonicalize and infer maintenance statuses so dashboard widgets no longer fall back to "Sin estado" when the Excel omits the field
- derive kilometers restantes from multiple columns and reuse the helper to keep vencida/próxima counts aligned with the ≤2.000 km rule across summary cards and filters
- improve the pie chart palette and status ordering so branch and estado selectors consistently reflect the normalized categories

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e2a98130f0832faa49bbbbc656f850